### PR TITLE
Moved Trivy to test/analysis workflow

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -150,32 +150,6 @@ jobs:
           allow_issue_writing: false
           fail_action: false
 
-  # https://github.com/marketplace/actions/aqua-security-trivy
-  trivy-repo:
-    name: Repository Report
-    needs:
-      - zap-backend
-      - zap-frontend
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.3.0
-        with:
-          scan-type: "fs"
-          format: "sarif"
-          output: "trivy-results.sarif"
-          ignore-unfixed: true
-          severity: "CRITICAL,HIGH"
-          security-checks: "vuln,secret,config"
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: "trivy-results.sarif"
-
   image-backend:
     name: Backend Image Handling
     needs:
@@ -284,7 +258,6 @@ jobs:
     needs:
       - image-backend
       - image-frontend
-      - trivy-repo
     runs-on: ubuntu-22.04
     environment:
       name: prod

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -74,3 +74,27 @@ jobs:
           cd frontend
           npm ci
           npm run test
+
+  # https://github.com/marketplace/actions/aqua-security-trivy
+  trivy:
+    name: Repository Report
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@0.3.0
+        with:
+          scan-type: "fs"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          ignore-unfixed: true
+          severity: "CRITICAL,HIGH"
+          security-checks: "vuln,secret,config"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
Trivy is kicking up security alerts in main merge, which stops the pipeline.  Moving to the test/analysis workflow means running on ready PR, so stops can happen sooner and more visibly.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-105-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-105-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)