### PR TITLE
Setup SonarCloud for Frontend using Action

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,36 +44,17 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Get npm cache directory
-        id: npm-cache-dir-frontend
-        run: |
-          echo "::set-output name=dir::$(npm config get cache)"
-
-      - uses: actions/cache@v3
-        id: npm-cache-frontend # use this to check for `cache-hit
+      - uses: bcgov-nr/action-test-and-analyse@v0.0.1
         with:
-          path: ${{ steps.npm-cache-dir-frontend.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Cache for test results
-        id: cache-frontend
-        uses: actions/cache@v3
-        with:
-          path: frontend/coverage
-          key: frontend-coverage-${{ github.run_number }}
-          restore-keys: |
-            frontend-coverage-
-
-      - name: Tests
-        run: |
-          cd frontend
-          npm ci
-          npm run test
+          commands: |
+            npm ci
+            npm run test
+          dir: frontend
+          sonar_args: |
+            -Dsonar.exclusions=**/coverage/**,**/node_modules/**
+            -Dsonar.organization=bcgov-sonarcloud
+            -Dsonar.projectKey=forest-client-frontend
+          sonar_project_token: ${{ secrets.SONAR_TOKEN_FRONTEND }}
 
   # https://github.com/marketplace/actions/aqua-security-trivy
   trivy:


### PR DESCRIPTION
SonarCloud has been set up in monorepo mode.  Test and Analyse Action only supports node at the moment, so the Java backend will have to wait a bit.

https://sonarcloud.io/project/overview?id=forest-client-backend
https://sonarcloud.io/project/overview?id=forest-client-frontend

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-166-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-166-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)