### PR TITLE
Workflows use ubuntu-22.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -59,7 +59,7 @@ jobs:
     env:
       ZONE: test
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys
@@ -79,7 +79,7 @@ jobs:
     env:
       ZONE: test
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys
@@ -101,7 +101,7 @@ jobs:
     env:
       ZONE: test
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys
@@ -136,7 +136,7 @@ jobs:
     env:
       ZONE: test
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys
@@ -165,7 +165,7 @@ jobs:
       PREV: test
       ZONE: prod
     environment: prod
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys
@@ -191,7 +191,7 @@ jobs:
     env:
       ZONE: prod
     environment: prod
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys
@@ -215,7 +215,7 @@ jobs:
       PREV: test
       ZONE: prod
     environment: prod
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys
@@ -254,7 +254,7 @@ jobs:
       PREV: test
       ZONE: prod
     environment: prod
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -61,7 +61,7 @@ jobs:
     name: Deploy Init
     needs:
       - builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys
@@ -78,7 +78,7 @@ jobs:
     name: Deploy Database
     needs:
       - builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys
@@ -97,7 +97,7 @@ jobs:
     name: Deploy Backend
     needs:
       - builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys
@@ -128,7 +128,7 @@ jobs:
     name: Deploy Frontend
     needs:
       - builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Deploys


### PR DESCRIPTION
For predictability and stability use ubuntu-22.04 instead of ubuntu-latest in workflows.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-176-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-176-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)