### PR TITLE
PR open and close cancel each other

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -6,7 +6,8 @@ on:
       - closed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # PR open and close use the same group, allowing only one at a time
+  group: pr-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # PR open and close use the same group, allowing only one at a time
+  group: pr-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Don't allow PR open and close workflows to run at the same time. This is confusing and can leave OpenShift artifacts behind.

Change:
- PR open and close use the same concurrency group name
- Newer runs cancel older runs

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-250-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-250-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)