### PR TITLE
fix: fixing endpoint naming to plural

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,8 @@
 # These owners will be the default owners for everything in the repo
 # unless a later match takes precedence, and will be requested for
 # review when someone opens a pull request.
-*       @paulushcgcj @mamartinezmejia
-
-# Backend changes requires review from backend developers
-/backend/       @paulushcgcj @brunoMarchiEncora
-
+*       @paulushcgcj @mamartinezmejia @brunoMarchiEncora
+/backend/       @paulushcgcj @brunoMarchiEncora @mamartinezmejia
+/frontend/       @paulushcgcj @mamartinezmejia
+/legacy/       @paulushcgcj @brunoMarchiEncora @mamartinezmejia
 /.github/workflows/       @paulushcgcj @DerekRoberts

--- a/backend/src/main/java/ca/bc/gov/app/configuration/RouteConfiguration.java
+++ b/backend/src/main/java/ca/bc/gov/app/configuration/RouteConfiguration.java
@@ -64,9 +64,9 @@ public class RouteConfiguration {
                           .required(true)
                           .examples(
                               Map.of(
-                                  "json",
+                                  MediaType.APPLICATION_JSON_VALUE,
                                   new Example().value(MediaType.APPLICATION_JSON_VALUE),
-                                  "eventstream",
+                                  MediaType.TEXT_EVENT_STREAM_VALUE,
                                   new Example().value(MediaType.TEXT_EVENT_STREAM_VALUE)
                               )
                           )
@@ -79,9 +79,9 @@ public class RouteConfiguration {
                           .required(true)
                           .examples(
                               Map.of(
-                                  "json",
+                                  MediaType.APPLICATION_JSON_VALUE,
                                   new Example().value(MediaType.APPLICATION_JSON_VALUE),
-                                  "eventstream",
+                                  MediaType.TEXT_EVENT_STREAM_VALUE,
                                   new Example().value(MediaType.TEXT_EVENT_STREAM_VALUE)
                               )
                           )

--- a/backend/src/main/java/ca/bc/gov/app/dto/orgbook/OrgBookNameDto.java
+++ b/backend/src/main/java/ca/bc/gov/app/dto/orgbook/OrgBookNameDto.java
@@ -2,26 +2,16 @@ package ca.bc.gov.app.dto.orgbook;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
-@Schema(name = "NamedResult")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record OrgBookNameDto(
-    @Schema(
-        name = "value",
-        title = "Name of the entity being searched",
-        example = "U3 POWER CORP",
-        requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    String value,
 
-    @Schema(
-        name = "topic_source_id",
-        title = "The incorporation ID",
-        example = "BC0772006",
-        requiredMode = Schema.RequiredMode.REQUIRED
-    )
+    String value,
+    @JsonProperty("sub_type")
+    String subType,
     @JsonProperty("topic_source_id")
-    String topicSourceId
+    String topicSourceId,
+    List<String>names
 ) {
 }

--- a/backend/src/main/java/ca/bc/gov/app/routes/client/ClientRouter.java
+++ b/backend/src/main/java/ca/bc/gov/app/routes/client/ClientRouter.java
@@ -49,13 +49,13 @@ public class ClientRouter implements BaseRouter {
             clientHandler.documentation(routeTagName())
         )
         .GET(
-            "/activeCountryCode",
+            "/activeCountryCodes",
             accept(MediaType.ALL),
             countryCodeHandler::handle,
             countryCodeHandler.documentation(routeTagName())
         )
         .GET(
-            "/activeCountryCode/{countryCode}",
+            "/activeCountryCodes/{countryCode}",
             accept(MediaType.ALL),
             provinceCodeHandler::handle,
             provinceCodeHandler.documentation(routeTagName())

--- a/backend/src/main/java/ca/bc/gov/app/service/orgbook/OrgBookApiService.java
+++ b/backend/src/main/java/ca/bc/gov/app/service/orgbook/OrgBookApiService.java
@@ -32,14 +32,20 @@ public class OrgBookApiService {
                 uriBuilder
                     .path("/v3/search/autocomplete")
                     .queryParam("q", CoreUtil.encodeString(clientName))
+                    .queryParam("inactive", "false")
+                    .queryParam("revoked", "false")
                     .build(new HashMap<>())
             )
             .accept(MediaType.APPLICATION_JSON)
             .exchangeToMono(
                 clientResponse -> clientResponse.bodyToMono(OrgBookResultListResponse.class)
             )
-            .flatMapMany(orgBookResultListResponse -> Flux.fromIterable(orgBookResultListResponse.results()))
-            .map(orgBookNameDto -> new ClientNameCodeDto(orgBookNameDto.topicSourceId(),orgBookNameDto.value()))
+            .log()
+            .flatMapMany(
+                orgBookResultListResponse -> Flux.fromIterable(orgBookResultListResponse.results()))
+            .filter(orgBookNameDto -> orgBookNameDto.subType().equalsIgnoreCase("entity_name"))
+            .map(orgBookNameDto -> new ClientNameCodeDto(orgBookNameDto.topicSourceId(),
+                orgBookNameDto.value()))
             .doOnNext(content -> log.info("OrgBook Name Lookup {} -> {}", clientName, content));
 
   }

--- a/backend/src/test/java/ca/bc/gov/app/endpoints/client/ClientHandlerIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/app/endpoints/client/ClientHandlerIntegrationTest.java
@@ -50,7 +50,7 @@ class ClientHandlerIntegrationTest extends AbstractTestContainerIntegrationTest 
     Function<UriBuilder, URI> uri = uriBuilder -> {
 
       UriBuilder localBuilder = uriBuilder
-          .path("/api/clients/activeCountryCode");
+          .path("/api/clients/activeCountryCodes");
 
       if (page != null) {
         localBuilder = localBuilder.queryParam("page", page);
@@ -85,7 +85,7 @@ class ClientHandlerIntegrationTest extends AbstractTestContainerIntegrationTest 
     Function<UriBuilder, URI> uri = uriBuilder -> {
 
       UriBuilder localBuilder = uriBuilder
-          .path("/api/clients/activeCountryCode/{countryCode}");
+          .path("/api/clients/activeCountryCodes/{countryCode}");
 
       if (page != null) {
         localBuilder = localBuilder.queryParam("page", page);


### PR DESCRIPTION
Changing endpoint names to plural

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-337-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-337-frontend.apps.silver.devops.gov.bc.ca/) available
[Legacy](https://nr-forest-client-337-legacy.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)