### PR TITLE
fix: reduce Dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,12 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: maven
     directory: /backend
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: "Backend"
       include: "scope"
@@ -18,7 +18,7 @@ updates:
   - package-ecosystem: npm
     directory: /frontend
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: "Frontend"
       include: "scope"


### PR DESCRIPTION
Dial down Dependabot PR updates from daily to weekly, which defaults to Mondays.  Hopefully this should recude the burden of managing updates.  (Mend Renovate is still being worked  on to replace Dependabot, since it offers batching and other features.)

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-361-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-361-frontend.apps.silver.devops.gov.bc.ca/) available
[Legacy](https://nr-forest-client-361-legacy.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)