### PR TITLE
Bump frontend Caddy to 2.6.4

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,7 @@ COPY . ./
 RUN npm ci --omit=dev && npm run build
 
 # Deployment container
-FROM caddy:2.4.6-alpine
+FROM caddy:2.6.4-alpine
 EXPOSE 3000
 COPY --from=builder /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=builder /app/dist /srv


### PR DESCRIPTION
Caddy 2.6.4 alpine upgrade has been problematic on the QuickStart.  Testing on your app.  Please DO NOT MERGE!

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-424-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-424-frontend.apps.silver.devops.gov.bc.ca/) available
[Legacy](https://nr-forest-client-424-legacy.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)