### PR TITLE
PR description add only for opened or reopened PRs

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -68,6 +68,7 @@ jobs:
 
   pr-greeting:
     name: PR Greeting
+    if: github.event.action == 'opened' || github.event.action == 'reopened'
     env:
       DOMAIN: apps.silver.devops.gov.bc.ca
       PREFIX: ${{ github.event.repository.name }}-${{ github.event.number }}


### PR DESCRIPTION
Only run PR comment adder on new or reopened PRs.  This prevents double-commenting (happens when GitHub responses time out) and avoids unnecessarily using a runner, which can be in short supply.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-485-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-485-frontend.apps.silver.devops.gov.bc.ca/) available
[Legacy](https://nr-forest-client-485-legacy.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)