### PR TITLE
feat: update caddy to 2.6.4

### DIFF
--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -30,4 +30,5 @@ encode {
 
 log {
 	output stdout
+	level {$LOG_LEVEL}
 }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,17 +1,23 @@
-# RedHat UBI 8 with nodejs 14
-FROM registry.access.redhat.com/ubi8/ubi:8.7-1112 AS builder
-RUN dnf module install -y nodejs:18
+# Build static files
+FROM node:alpine3.16 AS build
 
-# Install packages, build and keep only prod packages
 WORKDIR /app
-COPY . ./
-RUN npm ci --omit=dev && npm run build
+COPY . .
+RUN npm ci --omit=dev && npm run build && \
+    npm run build
 
-# Deployment container
-FROM caddy:2.4.6-alpine
-EXPOSE 3000
-COPY --from=builder /app/Caddyfile /etc/caddy/Caddyfile
+# Caddy
+FROM caddy:2.6.4-alpine
+
+# Copy static files and config
 COPY --from=builder /app/dist /srv
+COPY Caddyfile /etc/caddy/Caddyfile
 
-USER 1001
+# Packages and caddy format
+RUN apk add --no-cache ca-certificates && \
+    caddy fmt --overwrite /etc/caddy/Caddyfile
+
+# Port, health check and non-root user
+EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/
+USER 1001

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ FROM node:alpine3.16 AS build
 
 WORKDIR /app
 COPY . .
-RUN npm ci --omit=dev && npm run build && \
+RUN npm ci --omit=dev && \
     npm run build
 
 # Caddy

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,7 @@ RUN npm ci --omit=dev && npm run build && \
 FROM caddy:2.6.4-alpine
 
 # Copy static files and config
-COPY --from=builder /app/dist /srv
+COPY --from=build /app/dist /srv
 COPY Caddyfile /etc/caddy/Caddyfile
 
 # Packages and caddy format

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -108,6 +108,9 @@ objects:
                 name: ${NAME}-${ZONE}-${COMPONENT}
           containers:
             - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
+              securityContext:
+                capabilities:
+                  add: ["NET_BIND_SERVICE"]
               imagePullPolicy: Always
               name: ${NAME}
               volumeMounts:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -45,7 +45,7 @@ parameters:
   - name: VITE_KEYCLOAK_CLIENT_ID
     value: ""
   - name: LOG_LEVEL
-    decription: Caddy logging level
+    description: Caddy log level (debug, info, warn, error, panic, fatal)
     value: "info"
 objects:
   - apiVersion: v1

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -44,6 +44,9 @@ parameters:
     value: https://loginproxy.gov.bc.ca/auth
   - name: VITE_KEYCLOAK_CLIENT_ID
     value: ""
+  - name: LOG_LEVEL
+    decription: Caddy logging level
+    value: "info"
 objects:
   - apiVersion: v1
     kind: ImageStream
@@ -111,6 +114,9 @@ objects:
               securityContext:
                 capabilities:
                   add: ["NET_BIND_SERVICE"]
+              env:
+                - name: LOG_LEVEL
+                  value: ${LOG_LEVEL}
               imagePullPolicy: Always
               name: ${NAME}
               volumeMounts:


### PR DESCRIPTION
Caddy update plus the OpenShift security context it requires.  The builder base was changed from RHEL's UBI to Alpine, which Caddy uses too.

Features: 
- LOG_LEVEL, which defaults to "info" and can be set in the template
- Common base for build and deploy, which is a little faster and more stable
- Lots of security updates, including warnings in this project


---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-505-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-505-frontend.apps.silver.devops.gov.bc.ca/) available
[Legacy](https://nr-forest-client-505-legacy.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)