### PR TITLE
feat: add condition to show the logout modal

### DIFF
--- a/frontend/src/components/MainHeaderComponent.vue
+++ b/frontend/src/components/MainHeaderComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watchEffect } from "vue";
+import { ref, watchEffect, getCurrentInstance } from "vue";
 // Carbon
 import "@carbon/web-components/es/components/button/index";
 import "@carbon/web-components/es/components/ui-shell/index";
@@ -7,8 +7,11 @@ import type { CDSHeaderPanel } from "@carbon/web-components";
 import type CDSHeaderGlobalAction from "@carbon/web-components/es/components/ui-shell/header-global-action";
 // Composables
 import { isSmallScreen, isMediumScreen } from "@/composables/useScreenSize";
+import { useRoute } from "vue-router";
 // Types
 import { nodeEnv, appVersion } from "@/CoreConstants";
+// Routes
+import { CONFIRMATION_ROUTE_NAME } from "@/routes";
 // @ts-ignore
 import Logout16 from "@carbon/icons-vue/es/logout/16";
 // @ts-ignore
@@ -70,6 +73,23 @@ watchEffect((onCleanup) => {
     });
   }
 });
+
+const instance = getCurrentInstance();
+const session = instance?.appContext.config.globalProperties.$session;
+
+const logout = () => {
+  session?.logOut();
+}
+
+const route = useRoute();
+
+const onClickLogout = () => {
+  if (route.name === CONFIRMATION_ROUTE_NAME) {
+    logout();
+  } else {
+    logoutModalActive.value = true;
+  }
+}
 </script>
 
 <template>
@@ -120,7 +140,7 @@ watchEffect((onCleanup) => {
       data-id="logout-btn"
       kind="tertiary"
       size="sm"
-      @click.prevent="logoutModalActive = true"
+      @click.prevent="onClickLogout"
     >
       <span v-if="!isSmallScreen && !isMediumScreen">Logout</span>
       <Logout16 slot="icon" />
@@ -243,7 +263,7 @@ watchEffect((onCleanup) => {
       <cds-modal-footer-button 
         kind="danger" 
         class="cds--modal-submit-btn" 
-        v-on:click="$session?.logOut">
+        v-on:click="logout">
         Logout
         <Logout16 slot="icon" />
       </cds-modal-footer-button>

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -16,6 +16,8 @@ import ForestClientUserSession from "@/helpers/ForestClientUserSession";
 
 import { nodeEnv } from "@/CoreConstants";
 
+const CONFIRMATION_ROUTE_NAME = "confirmation";
+
 const routes = [
   {
     path: "/landing",
@@ -85,7 +87,7 @@ const routes = [
   },
   {
     path: "/form-submitted",
-    name: "confirmation",
+    name: CONFIRMATION_ROUTE_NAME,
     component: FormSubmittedPage,
     props: true,
     meta: {
@@ -245,7 +247,7 @@ router.beforeEach(async (to, from, next) => {
   }
 });
 
-export { routes, router };
+export { routes, router, CONFIRMATION_ROUTE_NAME };
 
 declare module 'vue-router' {
   // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

- When the current page is the Confirmation page (form-submitted):
  - Logs out without showing the logout modal;
- Otherwise:
  - Shows the logout modal as usual.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-21-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-21-frontend.apps.silver.devops.gov.bc.ca/) available
[Legacy](https://nr-forest-client-21-legacy.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)