### PR TITLE
fix: skip birthdate validation when business is not found

### DIFF
--- a/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
+++ b/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
@@ -53,7 +53,7 @@ watch(
 const validation = reactive<Record<string, boolean>>({
   businessType: !!formData.value.businessInformation.businessType,
   business: !!formData.value.businessInformation.businessName,
-  birthdate: !!formData.value.businessInformation.birthdate,
+  birthdate: true, // temporary value
 });
 
 const checkValid = () =>
@@ -77,6 +77,16 @@ const selectedOption = computed(() => {
       return BusinessTypeEnum.Unknow;
   }
 });
+
+const showBirthDate = computed(
+  () =>
+    validation.business &&
+    (selectedOption.value === BusinessTypeEnum.U ||
+      formData.value.businessInformation.clientType === ClientTypeEnum[ClientTypeEnum.RSP]),
+);
+
+// validation.birthdate initialization
+validation.birthdate = !showBirthDate.value || !!formData.value.businessInformation.businessName;
 
 const autoCompleteUrl = computed(
   () => `/api/clients/name/${formData.value.businessInformation.businessName || ""}`
@@ -201,13 +211,6 @@ watch([selectedOption], () => {
     showAutoCompleteInfo.value = true;
   }
 });
-
-const showBirthDate = computed(
-  () =>
-    validation.business &&
-    (selectedOption.value === BusinessTypeEnum.U ||
-      formData.value.businessInformation.clientType === ClientTypeEnum[ClientTypeEnum.RSP]),
-);
 
 watch(showBirthDate, (value) => {
   if (value) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Birthdate validation needs to be skipped when that field is not shown.

The value didn't get updated because the values which the `computed` `showBirthDate` depends on don't happen to change when the business is not found.

It was fixed by allowing that validation to get initialized with true.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-8-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-8-frontend.apps.silver.devops.gov.bc.ca/) available
[Legacy](https://nr-forest-client-8-legacy.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)