### PR TITLE
fix: prevent multiple clicks on the approve/reject buttons

### DIFF
--- a/frontend/cypress/e2e/SubmissionReviewPage.cy.ts
+++ b/frontend/cypress/e2e/SubmissionReviewPage.cy.ts
@@ -164,14 +164,16 @@ describe("Submission Review Page", () => {
     }
   });
 
+  const approveLabel = "Approve submission";
+  const rejectLabel = "Reject submission";
   const actions = [
     {
       action: "approve",
-      buttonLabel: "Approve submission",
+      buttonLabel: approveLabel,
     },
     {
       action: "reject",
-      buttonLabel: "Reject submission",
+      buttonLabel: rejectLabel,
     },
   ];
   actions.forEach(({ action, buttonLabel }) => {
@@ -226,11 +228,27 @@ describe("Submission Review Page", () => {
         it("should re-enable the buttons", () => {
           cy.wait("@action");
 
-          // all approve/reject buttons are enabled again.
-          actions.forEach(({ buttonLabel }) => {
-            cy.contains("cds-button", buttonLabel).should("not.have.attr", "disabled");
-            cy.contains("cds-modal-footer-button", buttonLabel).should("not.have.attr", "disabled");
-          });
+          // the approve/reject buttons are enabled again
+          cy.contains("cds-button", approveLabel).should("not.have.attr", "disabled");
+          cy.contains("cds-modal-footer-button", approveLabel).should("not.have.attr", "disabled");
+          cy.contains("cds-button", rejectLabel).should("not.have.attr", "disabled");
+
+          /*
+          For the Reject in the modal, it depends if the reason input is alread filled.
+          */
+          if (action === "reject") {
+            // Value is not empty
+            cy.get("#reject_reason_id").should("not.have.value", "");
+
+            // Thus button was properly re-enabled
+            cy.contains("cds-modal-footer-button", rejectLabel).should("not.have.attr", "disabled");
+          } else {
+            // Value is empty
+            cy.get("#reject_reason_id").should("have.value", "");
+
+            // Thus button remains disabled
+            cy.contains("cds-modal-footer-button", rejectLabel).should("have.attr", "disabled");
+          }
         });
       });
     });

--- a/frontend/src/pages/SubmissionReviewPage.vue
+++ b/frontend/src/pages/SubmissionReviewPage.vue
@@ -129,11 +129,16 @@ const rejectionReasonMessage = computed(() => {
   return [];
 });
 
+const submitDisabled = ref(false);
+
 // Submit the form changes to the backend
 const submit = (approved: boolean) => {
+  if (submitDisabled.value) return;
+  submitDisabled.value = true;
+
   rejectModal.value = false;
   approveModal.value = false;
-  const { response, error } = usePost(
+  const { response, error, loading } = usePost(
     `/api/clients/submissions/${id.value}`,
     {
       approved,
@@ -179,6 +184,10 @@ const submit = (approved: boolean) => {
       };
       toastBus.emit(toastNotification);
     }
+  });
+
+  watch(loading, (value) => {
+    submitDisabled.value = value;
   });
 };
 
@@ -556,12 +565,12 @@ const getLegacyUrl = ref((duplicatedClient) => {
         </cds-accordion>
 
         <div class="grouping-15" v-if="data.submissionType === 'Review new client' && (data.submissionStatus !== 'Approved' && data.submissionStatus !== 'Rejected')">
-          <cds-button kind="primary" @click="approveModal = !approveModal">
+          <cds-button kind="primary" @click="approveModal = !approveModal" :disabled="submitDisabled">
             <span>Approve submission</span>
             <Check16 slot="icon" />
           </cds-button>
           <span class="spacer" v-if="!isSmallScreen && !isMediumScreen"></span>
-          <cds-button kind="danger" @click="rejectModal = !rejectModal">
+          <cds-button kind="danger" @click="rejectModal = !rejectModal" :disabled="submitDisabled">
             <span>Reject submission</span>
             <Error16 slot="icon" />
           </cds-button>
@@ -595,6 +604,7 @@ const getLegacyUrl = ref((duplicatedClient) => {
           <cds-modal-footer-button 
             kind="primary" 
             @click="submit(true)"
+            :disabled="submitDisabled"
             class="cds--modal-submit-btn">
             <span>Approve submission</span>
             <Check16 slot="icon" />
@@ -650,7 +660,7 @@ const getLegacyUrl = ref((duplicatedClient) => {
           <cds-modal-footer-button 
             kind="danger"
             @click="submit(false)"
-            :disabled="rejectYesDisabled"
+            :disabled="rejectYesDisabled || submitDisabled"
             class="cds--modal-close-btn">
             <span>Reject submission</span>
             <Error16 slot="icon" />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Prevents a second click on the approve/reject buttons by disabling the buttons.
Reenables the buttons when the request to approve/reject gets responded. Useful when the request failed (error response), so the user can try again.


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-forest-client-13-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-forest-client-13-frontend.apps.silver.devops.gov.bc.ca/) available
[Legacy](https://nr-forest-client-13-legacy.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)