### PR TITLE
fix(fe:FSADT1-1225): display error message on dropdown

### DIFF
--- a/frontend/src/components/forms/AutoCompleteInputComponent.vue
+++ b/frontend/src/components/forms/AutoCompleteInputComponent.vue
@@ -183,6 +183,9 @@ watch(cdsComboBoxRef, async (value) => {
     }
   }
 });
+
+// For some reason, if helper-text is empty, invalid-text message doesn't work.
+const safeHelperText = computed(() => props.tip || " ");
 </script>
 
 <template>
@@ -196,7 +199,7 @@ watch(cdsComboBoxRef, async (value) => {
         :clear-selection-label="`Clear ${label}`"
         :required="required"
         :data-required-label="requiredLabel"
-        :helper-text="tip"
+        :helper-text="safeHelperText"
         :label="placeholder"
         :value="inputValue"
         filterable

--- a/frontend/src/components/forms/DropdownInputComponent.vue
+++ b/frontend/src/components/forms/DropdownInputComponent.vue
@@ -161,6 +161,9 @@ watch(cdsComboBoxRefArray, async (array) => {
     }
   }
 });
+
+// For some reason, if helper-text is empty, invalid-text message doesn't work.
+const safeHelperText = computed(() => props.tip || " ");
 </script>
 
 <template>
@@ -177,7 +180,7 @@ watch(cdsComboBoxRefArray, async (array) => {
         :required="required"
         :data-required-label="requiredLabel"
         filterable
-        :helper-text="tip"
+        :helper-text="safeHelperText"
         :label="placeholder"
         :value="selectedValue"
         :invalid="error ? true : false"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Sets a white-space as helper-text when none (or empty one) is provided. This is a workaround to make the error message (invalid-text) be effectively displayed.

It was also attempted to downgrade back to Carbon 2.0, but the issue was already there.

Fixes [FSADT1-1225](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT1-1225).

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---
Thanks for the PR!

Any successful deployments (not always required) will be available [here](https://nr-forest-client-19-frontend.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)