### PR TITLE
fix(fe:FSADT1-1006): Display numeric keyboard without classifying the field as a telephone

### DIFF
--- a/frontend/src/components/forms/DateInputComponent/DateInputPart.vue
+++ b/frontend/src/components/forms/DateInputComponent/DateInputPart.vue
@@ -44,14 +44,14 @@ const mask = "#".repeat(placeholder.length);
 
 const ariaLabel = `${props.parentTitle} ${datePartName}`;
 
-const cdsTextInput = ref<InstanceType<typeof CDSTextInput> | null>(null);
+const cdsTextInputRef = ref<InstanceType<typeof CDSTextInput> | null>(null);
 
-watch(cdsTextInput, async (value) => {
-  if (value) {
+watch(cdsTextInputRef, async (cdsTextInput) => {
+  if (cdsTextInput) {
     // wait for the DOM updates to complete
     await nextTick();
 
-    const input = value.shadowRoot?.querySelector("input");
+    const input = cdsTextInput.shadowRoot?.querySelector("input");
     if (input) {
       // display numeric keyboard on mobile devices
       input.inputMode = "numeric";
@@ -64,7 +64,7 @@ watch(cdsTextInput, async (value) => {
   <div class="input-group">
     <cds-text-input
       v-if="enabled"
-      ref="cdsTextInput"
+      ref="cdsTextInputRef"
       :id="id"
       :required="required"
       :label="capitalizedDatePart"

--- a/frontend/src/components/forms/DateInputComponent/DateInputPart.vue
+++ b/frontend/src/components/forms/DateInputComponent/DateInputPart.vue
@@ -2,6 +2,7 @@
 import { ref, watch, nextTick } from "vue";
 // Carbon
 import '@carbon/web-components/es/components/text-input/index';
+import type { CDSTextInput } from "@carbon/web-components";
 // Types
 import { DatePart } from "./common";
 
@@ -42,6 +43,21 @@ const placeholder = placeholders[props.datePart];
 const mask = "#".repeat(placeholder.length);
 
 const ariaLabel = `${props.parentTitle} ${datePartName}`;
+
+const cdsTextInput = ref<InstanceType<typeof CDSTextInput> | null>(null);
+
+watch(cdsTextInput, async (value) => {
+  if (value) {
+    // wait for the DOM updates to complete
+    await nextTick();
+
+    const input = value.shadowRoot?.querySelector("input");
+    if (input) {
+      // display numeric keyboard on mobile devices
+      input.inputMode = "numeric";
+    }
+  }
+});
 </script>
 
 <template>
@@ -53,7 +69,6 @@ const ariaLabel = `${props.parentTitle} ${datePartName}`;
       :required="required"
       :label="capitalizedDatePart"
       :aria-label="ariaLabel"
-      type="tel"
       :placeholder="placeholder"
       :value="selectedValue"
       :disabled="!enabled"

--- a/frontend/src/components/forms/TextInputComponent.vue
+++ b/frontend/src/components/forms/TextInputComponent.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref, watch, nextTick } from "vue";
 // Carbon
 import "@carbon/web-components/es/components/text-input/index";
+import type { CDSTextInput } from "@carbon/web-components";
 // Composables
 import { useEventBus } from "@vueuse/core";
 // Types
@@ -23,6 +24,7 @@ const props = withDefaults(
     required?: boolean;
     requiredLabel?: boolean;
     type?: TextInputType;
+    numeric?: boolean;
   }>(),
   {
     type: "text",
@@ -119,6 +121,20 @@ const selectValue = (event: any) => {
   isUserEvent.value = true
 };
 
+const cdsTextInput = ref<InstanceType<typeof CDSTextInput> | null>(null);
+
+watch([cdsTextInput, () => props.numeric], async ([cdsTextInputValue]) => {
+  if (cdsTextInputValue) {
+    // wait for the DOM updates to complete
+    await nextTick();
+
+    const input = cdsTextInputValue.shadowRoot?.querySelector("input");
+    if (input) {
+      // display either a numeric or an alphanumeric (default) keyboard on mobile devices
+      input.inputMode = props.numeric ? "numeric" : "text";
+    }
+  }
+});
 </script>
 
 <template>
@@ -126,6 +142,7 @@ const selectValue = (event: any) => {
     <div class="input-group">
       <cds-text-input
         v-if="enabled"
+        ref="cdsTextInput"
         :id="id"
         :required="required"
         :label="label"

--- a/frontend/src/components/forms/TextInputComponent.vue
+++ b/frontend/src/components/forms/TextInputComponent.vue
@@ -24,6 +24,7 @@ const props = withDefaults(
     required?: boolean;
     requiredLabel?: boolean;
     type?: TextInputType;
+    /** Display numeric virtual keyboard. Note: do not use this when type is tel. */
     numeric?: boolean;
   }>(),
   {

--- a/frontend/src/components/forms/TextInputComponent.vue
+++ b/frontend/src/components/forms/TextInputComponent.vue
@@ -24,6 +24,7 @@ const props = withDefaults(
     required?: boolean;
     requiredLabel?: boolean;
     type?: TextInputType;
+
     /** Display numeric virtual keyboard. Note: do not use this when type is tel. */
     numeric?: boolean;
   }>(),

--- a/frontend/src/components/forms/TextInputComponent.vue
+++ b/frontend/src/components/forms/TextInputComponent.vue
@@ -123,14 +123,14 @@ const selectValue = (event: any) => {
   isUserEvent.value = true
 };
 
-const cdsTextInput = ref<InstanceType<typeof CDSTextInput> | null>(null);
+const cdsTextInputRef = ref<InstanceType<typeof CDSTextInput> | null>(null);
 
-watch([cdsTextInput, () => props.numeric], async ([cdsTextInputValue]) => {
-  if (cdsTextInputValue) {
+watch([cdsTextInputRef, () => props.numeric], async ([cdsTextInput]) => {
+  if (cdsTextInput) {
     // wait for the DOM updates to complete
     await nextTick();
 
-    const input = cdsTextInputValue.shadowRoot?.querySelector("input");
+    const input = cdsTextInput.shadowRoot?.querySelector("input");
     if (input) {
       // display either a numeric or an alphanumeric (default) keyboard on mobile devices
       input.inputMode = props.numeric ? "numeric" : "text";
@@ -144,7 +144,7 @@ watch([cdsTextInput, () => props.numeric], async ([cdsTextInputValue]) => {
     <div class="input-group">
       <cds-text-input
         v-if="enabled"
-        ref="cdsTextInput"
+        ref="cdsTextInputRef"
         :id="id"
         :required="required"
         :label="label"

--- a/frontend/src/components/grouping/AddressGroupComponent.vue
+++ b/frontend/src/components/grouping/AddressGroupComponent.vue
@@ -9,7 +9,6 @@ import { useFocus } from "@/composables/useFocus";
 // Types
 import type { CodeNameType, BusinessSearchResult } from "@/dto/CommonTypesDto";
 import type { Address } from "@/dto/ApplyClientNumberDto";
-import type { TextInputType} from "@/components/types"
 // Validators
 import { getValidations } from "@/helpers/validators/GlobalValidators";
 import { submissionValidation } from "@/helpers/validators/SubmissionValidators";
@@ -166,12 +165,12 @@ const postalCodePlaceholder = computed(() => {
   }
 });
 
-const postalCodeInputType = computed<TextInputType>(() => {
+const postalCodeNumeric = computed<boolean>(() => {
   switch (selectedValue.country.value) {
     case "CA":
-      return "text";
+      return false;
     default:
-      return "tel";
+      return true;
   }
 });
 
@@ -353,7 +352,7 @@ watch([detailsData], () => {
     <text-input-component
       :id="'postalCode_' + id"
       :label="postalCodeNaming"
-      :type="postalCodeInputType"
+      :numeric="postalCodeNumeric"
       required
       required-label
       placeholder=""

--- a/frontend/stub/mappings/backend.json
+++ b/frontend/stub/mappings/backend.json
@@ -107,7 +107,7 @@
     {
       "name": "Province Codes",
       "request": {
-        "urlPattern": "/api/countries/(.*)/provinces?page=0&size=250",
+        "urlPattern": "/api/countries/([A-Z]+)/provinces\\?page=0&size=250",
         "method": "GET"
       },
       "response": {
@@ -132,7 +132,7 @@
     {
       "name": "Get Country by CountryCode",
       "request": {
-        "urlPattern": "/api/countries/(.*)",
+        "urlPattern": "/api/countries/([A-Z]+)",
         "method": "GET"
       },
       "response": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Uses inputmode="numeric" instead of type="tel", unless the field indeed refers to a telephone value.
This prevents screen readers from announcing the field as a telephone when it's not.

Fixes [FSADT1-1006](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT1-1006)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---
Thanks for the PR!

Any successful deployments (not always required) will be available [here](https://nr-forest-client-43-frontend.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)

---
Thanks for the PR!

Any successful deployments (not always required) will be available [here](https://nr-forest-client-43-frontend.apps.silver.devops.gov.bc.ca/)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge-main.yml)