### PR TITLE
feat(fe:FSADT1-1257): add required input purpose information

### DIFF
--- a/frontend/src/components/forms/AutoCompleteInputComponent.vue
+++ b/frontend/src/components/forms/AutoCompleteInputComponent.vue
@@ -24,6 +24,7 @@ const props = withDefaults(defineProps<{
     showLoadingAfterTime?: number;
     required?: boolean;
     requiredLabel?: boolean;
+    autocomplete?: string;
   }>(),
   {
     showLoadingAfterTime: 2000,
@@ -194,6 +195,7 @@ const safeHelperText = computed(() => props.tip || " ");
       <cds-combo-box
         ref="cdsComboBoxRef"
         :id="id"
+        :autocomplete="autocomplete"
         :title-text="label"
         :aria-label="label"
         :clear-selection-label="`Clear ${label}`"

--- a/frontend/src/components/forms/DateInputComponent/DateInputPart.vue
+++ b/frontend/src/components/forms/DateInputComponent/DateInputPart.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
   enabled?: boolean;
   invalid: boolean;
   required?: boolean;
+  autocomplete?: string;
 }>();
 
 const emit = defineEmits<{
@@ -66,6 +67,7 @@ watch(cdsTextInputRef, async (cdsTextInput) => {
       v-if="enabled"
       ref="cdsTextInputRef"
       :id="id"
+      :autocomplete="autocomplete"
       :required="required"
       :label="capitalizedDatePart"
       :aria-label="ariaLabel"

--- a/frontend/src/components/forms/DateInputComponent/index.vue
+++ b/frontend/src/components/forms/DateInputComponent/index.vue
@@ -44,6 +44,7 @@ const props = withDefaults(
     requiredLabel?: boolean;
     required?: boolean;
     autoMoveFocus?: boolean;
+    autocomplete?: [string, string, string];
   }>(),
   {
     yearValidations: () => [],
@@ -443,6 +444,7 @@ const datePartComponentRefs = {
         @blur="(event: any) => onBlurYear(event.target.value)"
         @input="selectYear"
         :required="required"
+        :autocomplete="autocomplete && autocomplete[0]"
       />
       <date-input-part
         :ref="datePartComponentRefs[DatePart.month]"
@@ -455,6 +457,7 @@ const datePartComponentRefs = {
         @blur="(event: any) => onBlurMonth(event.target.value)"
         @input="selectMonth"
         :required="required"
+        :autocomplete="autocomplete && autocomplete[1]"
       />
       <date-input-part
         :ref="datePartComponentRefs[DatePart.day]"
@@ -467,6 +470,7 @@ const datePartComponentRefs = {
         @blur="(event: any) => onBlurDay(event.target.value)"
         @input="selectDay"
         :required="required"
+        :autocomplete="autocomplete && autocomplete[2]"
       />
     </div>
     <div class="cds--form-requirement field-error">{{ error }}</div>

--- a/frontend/src/components/forms/DropdownInputComponent.vue
+++ b/frontend/src/components/forms/DropdownInputComponent.vue
@@ -178,6 +178,7 @@ const safeHelperText = computed(() => props.tip || " ");
         ref="cdsComboBoxArrayRef"
         :key="time"
         :id="id"
+        :autocomplete="autocomplete"
         :title-text="label"
         :aria-label="label"
         :clear-selection-label="`Clear ${label}`"

--- a/frontend/src/components/forms/DropdownInputComponent.vue
+++ b/frontend/src/components/forms/DropdownInputComponent.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
   errorMessage?: string;
   required?: boolean;
   requiredLabel?: boolean;
+  autocomplete?: string;
 }>();
 
 //Events we emit during component lifecycle

--- a/frontend/src/components/forms/TextInputComponent.vue
+++ b/frontend/src/components/forms/TextInputComponent.vue
@@ -24,6 +24,7 @@ const props = withDefaults(
     required?: boolean;
     requiredLabel?: boolean;
     type?: TextInputType;
+    autocomplete?: string;
 
     /** Display numeric virtual keyboard. Note: do not use this when type is tel. */
     numeric?: boolean;
@@ -146,6 +147,7 @@ watch([cdsTextInputRef, () => props.numeric], async ([cdsTextInput]) => {
         v-if="enabled"
         ref="cdsTextInputRef"
         :id="id"
+        :autocomplete="autocomplete"
         :required="required"
         :label="label"
         :aria-label="label"

--- a/frontend/src/components/grouping/AddressGroupComponent.vue
+++ b/frontend/src/components/grouping/AddressGroupComponent.vue
@@ -272,6 +272,7 @@ watch([detailsData], () => {
       <AutoCompleteInputComponent
         :id="'addr_' + id"
         label="Street address or PO box"
+        :autocomplete="id === 0 ? 'address-line1' : 'off'"
         required
         required-label
         placeholder=""
@@ -294,6 +295,7 @@ watch([detailsData], () => {
     <text-input-component
       :id="'city_' + id"
       label="City"
+      :autocomplete="id === 0 ? 'address-level2' : 'off'"
       required
       required-label
       placeholder=""
@@ -320,6 +322,7 @@ watch([detailsData], () => {
       <dropdown-input-component
         :id="'province_' + id"
         :label="provinceNaming"
+        :autocomplete="id === 0 ? 'address-level1' : 'off'"
         required
         required-label
         :initial-value="selectedValue.province.text"
@@ -336,6 +339,7 @@ watch([detailsData], () => {
     <dropdown-input-component
       :id="'country_' + id"
       label="Country"
+      :autocomplete="id === 0 ? 'country-name' : 'off'"
       required
       required-label
       :initial-value="selectedValue.country.text"
@@ -352,6 +356,7 @@ watch([detailsData], () => {
     <text-input-component
       :id="'postalCode_' + id"
       :label="postalCodeNaming"
+      :autocomplete="id === 0 ? 'postal-code' : 'off'"
       :numeric="postalCodeNumeric"
       required
       required-label

--- a/frontend/src/components/grouping/AddressGroupComponent.vue
+++ b/frontend/src/components/grouping/AddressGroupComponent.vue
@@ -239,6 +239,11 @@ watch([detailsData], () => {
     setTimeout(() => (addressControl.value = false), 200);
   }
 });
+
+/**
+ * Adds a named group to the fields. Specially useful when BCEID_MULTI_ADDRESS is enabled.
+ */
+const section = (index: number, purpose: string) => `section-address-${index} ${purpose}`;
 </script>
 
 <template>
@@ -272,7 +277,7 @@ watch([detailsData], () => {
       <AutoCompleteInputComponent
         :id="'addr_' + id"
         label="Street address or PO box"
-        :autocomplete="id === 0 ? 'address-line1' : 'off'"
+        :autocomplete="section(id, 'address-line1')"
         required
         required-label
         placeholder=""
@@ -295,7 +300,7 @@ watch([detailsData], () => {
     <text-input-component
       :id="'city_' + id"
       label="City"
-      :autocomplete="id === 0 ? 'address-level2' : 'off'"
+      :autocomplete="section(id, 'address-level2')"
       required
       required-label
       placeholder=""
@@ -322,7 +327,7 @@ watch([detailsData], () => {
       <dropdown-input-component
         :id="'province_' + id"
         :label="provinceNaming"
-        :autocomplete="id === 0 ? 'address-level1' : 'off'"
+        :autocomplete="section(id, 'address-level1')"
         required
         required-label
         :initial-value="selectedValue.province.text"
@@ -339,7 +344,7 @@ watch([detailsData], () => {
     <dropdown-input-component
       :id="'country_' + id"
       label="Country"
-      :autocomplete="id === 0 ? 'country-name' : 'off'"
+      :autocomplete="section(id, 'country-name')"
       required
       required-label
       :initial-value="selectedValue.country.text"
@@ -356,7 +361,7 @@ watch([detailsData], () => {
     <text-input-component
       :id="'postalCode_' + id"
       :label="postalCodeNaming"
-      :autocomplete="id === 0 ? 'postal-code' : 'off'"
+      :autocomplete="section(id, 'postal-code')"
       :numeric="postalCodeNumeric"
       required
       required-label

--- a/frontend/src/components/grouping/ContactGroupComponent.vue
+++ b/frontend/src/components/grouping/ContactGroupComponent.vue
@@ -203,6 +203,7 @@ const logoutAndRedirect = () => {
       :id="'phoneNumber_' + id"
       label="Phone number"
       type="tel"
+      :autocomplete="id === 0 ? 'tel' : undefined"
       placeholder="( ) ___-____"
       mask="(###) ###-####"
       v-model="selectedValue.phoneNumber"

--- a/frontend/src/components/grouping/ContactGroupComponent.vue
+++ b/frontend/src/components/grouping/ContactGroupComponent.vue
@@ -206,7 +206,7 @@ const logoutAndRedirect = () => {
       :id="'phoneNumber_' + id"
       label="Phone number"
       type="tel"
-      :autocomplete="id === 0 ? 'tel' : 'off'"
+      :autocomplete="id === 0 ? 'section-contact-0 tel' : 'off'"
       placeholder="( ) ___-____"
       mask="(###) ###-####"
       v-model="selectedValue.phoneNumber"

--- a/frontend/src/components/grouping/ContactGroupComponent.vue
+++ b/frontend/src/components/grouping/ContactGroupComponent.vue
@@ -152,6 +152,7 @@ const logoutAndRedirect = () => {
         :id="'firstName_' + id"
         label="First name"
         placeholder=""
+        autocomplete="off"
         v-model="selectedValue.firstName"
         :validations="[
           ...getValidations('location.contacts.*.firstName'),
@@ -169,6 +170,7 @@ const logoutAndRedirect = () => {
         :id="'lastName_' + id"
         label="Last name"
         placeholder=""
+        autocomplete="off"
         v-model="selectedValue.lastName"
         :validations="[
           ...getValidations('location.contacts.*.lastName'),
@@ -186,6 +188,7 @@ const logoutAndRedirect = () => {
         :id="'email_' + id"
         label="Email address"
         placeholder=""
+        autocomplete="off"
         v-model="selectedValue.email"
         :validations="[
           ...getValidations('location.contacts.*.email'),
@@ -203,7 +206,7 @@ const logoutAndRedirect = () => {
       :id="'phoneNumber_' + id"
       label="Phone number"
       type="tel"
-      :autocomplete="id === 0 ? 'tel' : undefined"
+      :autocomplete="id === 0 ? 'tel' : 'off'"
       placeholder="( ) ___-____"
       mask="(###) ###-####"
       v-model="selectedValue.phoneNumber"

--- a/frontend/src/pages/FormBCSCPage.vue
+++ b/frontend/src/pages/FormBCSCPage.vue
@@ -499,6 +499,8 @@ const updateDistrict = (value: CodeNameType | undefined) => {
       <text-input-component
         id="phoneNumberId"
         label="Phone number"
+        type="tel"
+        autocomplete="tel"
         placeholder="( ) ___-____"
         :enabled="true"
         v-model="formData.location.contacts[0].phoneNumber"

--- a/frontend/src/pages/FormBCeIDPage.vue
+++ b/frontend/src/pages/FormBCeIDPage.vue
@@ -432,75 +432,72 @@ watch(cdsProgressStepArray, async (array) => {
   </div>
 
   <div class="form-steps">
-
-    <form>
-      <div v-if="currentTab == 0" class="form-steps-01">
-        <div class="form-steps-01-title">
-          <h2 data-scroll="scroll-0">Before you begin</h2>
-          <ol type="1" class="bulleted-list body-compact-01">
-            <li>A registered business must be in good standing with BC Registries</li>
-            <li>
-              You must be able to receive email at
-              <b>{{ submitterContact.email }}</b>
-            </li>
-          </ol>
-        </div>
-
-        <hr class="divider" />
-
-        <div class="form-steps-section">
-          <business-information-wizard-step
-            v-model:data="formData"
-            :active="currentTab == 0"
-            :title="progressData[0].title"
-            :districts-list="formattedDistrictsList"
-            @valid="validateStep"
-          />
-        </div>
+    <div v-if="currentTab == 0" class="form-steps-01">
+      <div class="form-steps-01-title">
+        <h2 data-scroll="scroll-0">Before you begin</h2>
+        <ol type="1" class="bulleted-list body-compact-01">
+          <li>A registered business must be in good standing with BC Registries</li>
+          <li>
+            You must be able to receive email at
+            <b>{{ submitterContact.email }}</b>
+          </li>
+        </ol>
       </div>
 
-      <div v-if="currentTab == 1" class="form-steps-02">
-        <div class="form-steps-section">
-          <h2 data-scroll="scroll-1">
-            <div data-scroll="step-title" class="header-offset"></div>
-            {{ progressData[1].title }}
-          </h2>
+      <hr class="divider" />
 
-          <div class="form-steps-section-01">
-            <h3>This is the primary address where you will receive mail.</h3>
-          </div>
-
-          <address-wizard-step
-            v-model:data="formData"
-            :active="currentTab == 1"
-            @valid="validateStep"
-          />
-        </div>
+      <div class="form-steps-section">
+        <business-information-wizard-step
+          v-model:data="formData"
+          :active="currentTab == 0"
+          :title="progressData[0].title"
+          :districts-list="formattedDistrictsList"
+          @valid="validateStep"
+        />
       </div>
+    </div>
 
-      <div v-if="currentTab == 2" class="form-steps-03">
-        <div class="form-steps-section">
-          <h2 data-scroll="scroll-2">
-            <div data-scroll="step-title" class="header-offset"></div>
-            {{ progressData[2].title }}
-          </h2>
+    <div v-if="currentTab == 1" class="form-steps-02">
+      <div class="form-steps-section">
+        <h2 data-scroll="scroll-1">
+          <div data-scroll="step-title" class="header-offset"></div>
+          {{ progressData[1].title }}
+        </h2>
 
-          <div class="form-steps-section-01">
-            <h3>Add authorized people to the account</h3>
-            <p class="body-02 light-theme-text-text-primary">
-              Review your name and email address. They’re from your BCeID.
-            </p>
-          </div>
-
-          <contact-wizard-step
-            v-model:data="formData"
-            :active="currentTab == 2"
-            @valid="validateStep"
-            ref="contactWizardRef"
-          />
+        <div class="form-steps-section-01">
+          <h3>This is the primary address where you will receive mail.</h3>
         </div>
+
+        <address-wizard-step
+          v-model:data="formData"
+          :active="currentTab == 1"
+          @valid="validateStep"
+        />
       </div>
-    </form>
+    </div>
+
+    <div v-if="currentTab == 2" class="form-steps-03">
+      <div class="form-steps-section">
+        <h2 data-scroll="scroll-2">
+          <div data-scroll="step-title" class="header-offset"></div>
+          {{ progressData[2].title }}
+        </h2>
+
+        <div class="form-steps-section-01">
+          <h3>Add authorized people to the account</h3>
+          <p class="body-02 light-theme-text-text-primary">
+            Review your name and email address. They’re from your BCeID.
+          </p>
+        </div>
+
+        <contact-wizard-step
+          v-model:data="formData"
+          :active="currentTab == 2"
+          @valid="validateStep"
+          ref="contactWizardRef"
+        />
+      </div>
+    </div>
 
     <div v-if="currentTab == 3" class="form-steps-04">
 

--- a/frontend/src/pages/FormBCeIDPage.vue
+++ b/frontend/src/pages/FormBCeIDPage.vue
@@ -433,75 +433,74 @@ watch(cdsProgressStepArray, async (array) => {
 
   <div class="form-steps">
 
-    <div v-if="currentTab == 0" class="form-steps-01">
-      <div class="form-steps-01-title">
-        <h2 data-scroll="scroll-0">Before you begin</h2>
-        <ol type="1" class="bulleted-list body-compact-01">
-          <li>
-            A registered business must be in good standing with BC
-            Registries
-          </li>
-          <li>
-            You must be able to receive email at
-            <b>{{ submitterContact.email }}</b>
-          </li>
-        </ol>
-      </div>
+    <form>
+      <div v-if="currentTab == 0" class="form-steps-01">
+        <div class="form-steps-01-title">
+          <h2 data-scroll="scroll-0">Before you begin</h2>
+          <ol type="1" class="bulleted-list body-compact-01">
+            <li>A registered business must be in good standing with BC Registries</li>
+            <li>
+              You must be able to receive email at
+              <b>{{ submitterContact.email }}</b>
+            </li>
+          </ol>
+        </div>
 
-      <hr class="divider" />
+        <hr class="divider" />
 
-      <div class="form-steps-section">
-        <business-information-wizard-step
+        <div class="form-steps-section">
+          <business-information-wizard-step
             v-model:data="formData"
             :active="currentTab == 0"
             :title="progressData[0].title"
             :districts-list="formattedDistrictsList"
             @valid="validateStep"
-        />
-      </div>
-    </div>
-
-    <div v-if="currentTab == 1" class="form-steps-02">
-      <div class="form-steps-section">
-        <h2 data-scroll="scroll-1">
-          <div data-scroll="step-title" class="header-offset"></div>
-          {{ progressData[1].title}}
-        </h2>
-        
-        <div class="form-steps-section-01">
-          <h3>This is the primary address where you will receive mail.</h3>
+          />
         </div>
-      
-        <address-wizard-step
+      </div>
+
+      <div v-if="currentTab == 1" class="form-steps-02">
+        <div class="form-steps-section">
+          <h2 data-scroll="scroll-1">
+            <div data-scroll="step-title" class="header-offset"></div>
+            {{ progressData[1].title }}
+          </h2>
+
+          <div class="form-steps-section-01">
+            <h3>This is the primary address where you will receive mail.</h3>
+          </div>
+
+          <address-wizard-step
             v-model:data="formData"
             :active="currentTab == 1"
             @valid="validateStep"
           />
-      </div>    
-    </div>
+        </div>
+      </div>
 
-    <div v-if="currentTab == 2" class="form-steps-03">
-      <div class="form-steps-section">
-        <h2 data-scroll="scroll-2">
-          <div data-scroll="step-title" class="header-offset"></div>
-          {{ progressData[2].title}}
-        </h2>
-        
-        <div class="form-steps-section-01">
-          <h3>Add authorized people to the account</h3>
+      <div v-if="currentTab == 2" class="form-steps-03">
+        <div class="form-steps-section">
+          <h2 data-scroll="scroll-2">
+            <div data-scroll="step-title" class="header-offset"></div>
+            {{ progressData[2].title }}
+          </h2>
+
+          <div class="form-steps-section-01">
+            <h3>Add authorized people to the account</h3>
             <p class="body-02 light-theme-text-text-primary">
               Review your name and email address. They’re from your BCeID.
             </p>
-        </div>
-      
-        <contact-wizard-step
+          </div>
+
+          <contact-wizard-step
             v-model:data="formData"
             :active="currentTab == 2"
             @valid="validateStep"
             ref="contactWizardRef"
           />
+        </div>
       </div>
-    </div>
+    </form>
 
     <div v-if="currentTab == 3" class="form-steps-04">
 

--- a/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
+++ b/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
@@ -363,7 +363,7 @@ const updateDistrict = (value: CodeNameType | undefined) => {
       <AutoCompleteInputComponent
         v-if="selectedOption === BusinessTypeEnum.R"
         id="business"
-        label="BC registered business name"
+        autocomplete="organization"
         required
         required-label
         tip="Start typing to search for your BC registered business name"
@@ -509,6 +509,7 @@ const updateDistrict = (value: CodeNameType | undefined) => {
       <date-input-component
         id="birthdate"
         title="Date of birth"
+        :autocomplete="['bday-year', 'bday-month', 'bday-day']"
         v-model="formData.businessInformation.birthdate"
         :enabled="true"
         :validations="[...getValidations('businessInformation.birthdate')]"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Adds required input purpose information as autocomplete attributes.

Note 1: the purpose token should be set only for information about the user who is filling the form. Otherwise we use either "off" to make it clear this is not about the end user (the user who is filling the form in) - for example, information about additional contacts - or we just omit it - we do it when the field has no matching purpose in the list of [Input Purposes for User Interface Components](https://www.w3.org/TR/WCAG21/#input-purposes).

Note 2: for fields where the data may or may not be about the end user - in case the user filling in is an agent, the address is not about him/her at all - the purpose was kept anyway, since it would be useful in case the user filling in is the proprietary, and the agent in turn could just dismiss it.

Note 3: regardless of the potential usefulness of this, the autocomplete functionality was not enabled because it doesn't play well with our custom components, specially in the Address step - I guess it would require some UI/UX/development reformulation. Anyway this should suffice for satisfying the WCAG requirement as pointed in the following statement:

> Note that the [WCAG 2.1 Success Criterion 1.3.5: Identify Input Purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html) does not require that [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)/autofill actually work - merely that form fields that relate to specific personal user information are programmatically identified. This means that the criterion can be passed (by adding the relevant autocomplete attributes to individual form fields) even when autocompletion for the form itself has been turned off.

(source: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion)

Fixes [FSADT1-1257](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT1-1257)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-21-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-21-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)