### PR TITLE
fix(fe:FSADT1-1283): keep the button Next enabled on step 1

### DIFF
--- a/frontend/src/pages/FormBCeIDPage.vue
+++ b/frontend/src/pages/FormBCeIDPage.vue
@@ -407,6 +407,11 @@ watch(cdsProgressStepArray, async (array) => {
     }
   }
 });
+
+const individualValid = ref(false);
+const setIndividualValid = (valid: boolean) => {
+  individualValid.value = valid;
+};
 </script>
 
 <template>
@@ -468,6 +473,8 @@ watch(cdsProgressStepArray, async (array) => {
           :districts-list="formattedDistrictsList"
           @valid="validateStep"
           :auto-focus="autoFocusFirstStep"
+          :individual-valid="individualValid"
+          :set-individual-valid="setIndividualValid"
         />
       </div>
     </div>

--- a/frontend/src/pages/FormBCeIDPage.vue
+++ b/frontend/src/pages/FormBCeIDPage.vue
@@ -408,9 +408,9 @@ watch(cdsProgressStepArray, async (array) => {
   }
 });
 
-const individualValid = ref(false);
-const setIndividualValid = (valid: boolean) => {
-  individualValid.value = valid;
+const individualValidInd = ref(false);
+const setIndividualValidInd = (valid: boolean) => {
+  individualValidInd.value = valid;
 };
 </script>
 
@@ -473,8 +473,8 @@ const setIndividualValid = (valid: boolean) => {
           :districts-list="formattedDistrictsList"
           @valid="validateStep"
           :auto-focus="autoFocusFirstStep"
-          :individual-valid="individualValid"
-          :set-individual-valid="setIndividualValid"
+          :individual-valid-ind="individualValidInd"
+          :set-individual-valid-ind="setIndividualValidInd"
         />
       </div>
     </div>

--- a/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
+++ b/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
@@ -37,8 +37,8 @@ const props = defineProps<{
   title: string;
   districtsList: Array<CodeNameType>;
   autoFocus?: boolean;
-  individualValid?: boolean;
-  setIndividualValid?: (valid: boolean) => void;
+  individualValidInd?: boolean;
+  setIndividualValidInd?: (valid: boolean) => void;
 }>();
 
 const emit = defineEmits<{
@@ -71,7 +71,7 @@ const validation = reactive<Record<string, boolean>>({
   business: !!formData.value.businessInformation.businessName,
   birthdate: true, // temporary value
   district: false,
-  individual: props.individualValid, // occasionally pre-filled value
+  individual: props.individualValidInd, // occasionally pre-filled value
 });
 
 const checkValid = () =>
@@ -255,7 +255,7 @@ const checkForIndividualValid = (lastName: string) => {
 watch(
   () => validation.individual,
   () => {
-    props.setIndividualValid?.(validation.individual);
+    props.setIndividualValidInd?.(validation.individual);
   },
 );
 

--- a/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
+++ b/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
@@ -319,6 +319,9 @@ watch([individualCheck, selectedOption, soleProprietorOwner], ([individualCheckV
 watch([selectedOption], () => {
   toggleErrorMessages();
 
+  // reset soleProprietorOwner
+  soleProprietorOwner.value = "";
+
   // Unregistered Proprietorship
   if (selectedOption.value === BusinessTypeEnum.U) {
     const fromName = `${ForestClientUserSession.user?.firstName} ${ForestClientUserSession.user?.lastName}`;

--- a/frontend/tests/pages/bceid/BusinessInformationWizardStep.cy.ts
+++ b/frontend/tests/pages/bceid/BusinessInformationWizardStep.cy.ts
@@ -228,6 +228,73 @@ describe('<BusinessInformationWizardStep />', () => {
     cy.get("cds-inline-notification").should("not.exist");
   });
 
+  describe("when a Registered individual business gets selected", () => {
+    let callsSetIndividualValid = [];
+    const functionWrapper = {
+      setIndividualValid: (value: boolean) => {
+        callsSetIndividualValid.push(value);
+      },
+    };
+    const { setIndividualValid } = functionWrapper;
+    beforeEach(() => {
+      callsSetIndividualValid = [];
+      cy.mount(BusinessInformationWizardStep, {
+        props: {
+          data: {
+            businessInformation: {
+              businessType: "",
+              legalType: "",
+              clientType: "",
+              registrationNumber: "",
+              businessName: "",
+              goodStandingInd: "",
+              birthdate: "",
+              address: "",
+            },
+            location: {
+              contacts: [
+                {
+                  email: "john@doe.com",
+                  firstName: "John",
+                },
+              ],
+            },
+          } as unknown as FormDataDto,
+          districtsList: districts,
+          active: false,
+          individualValid: false,
+          setIndividualValid,
+        },
+        global,
+      });
+
+      cy.get("#businessTyperbR").click();
+
+      cy.get("#business").should("be.visible").shadow().find("input").type("Valid");
+      cy.wait("@searchCompany");
+
+      cy.get("cds-combo-box-item[data-id='XX9016140']").click();
+      cy.wrap(callsSetIndividualValid).should((value) => {
+        const lastCall = value.slice(-1)[0];
+        expect(lastCall).to.equal(true);
+      });
+    });
+
+    describe("and type of business is changed to Unregistered", () => {
+      beforeEach(() => {
+        callsSetIndividualValid = [];
+        cy.get("#businessTyperbU").click();
+      })
+      it("should re-check with user's last name", () => {
+        cy.wait("@checkIndividualUser");
+        cy.wrap(callsSetIndividualValid).should((value) => {
+          const lastCall = value.slice(-1)[0];
+          expect(lastCall).to.equal(true);
+        });
+      });
+    });
+  });
+
   describe("when props.individualValue is true", () => {
     const individualValid = true;
     let callsSetIndividualValid = [];
@@ -277,7 +344,8 @@ describe('<BusinessInformationWizardStep />', () => {
         it("should re-check individual validation", () => {
           cy.wait("@checkIndividualUser");
           cy.wrap(callsSetIndividualValid).should((value) => {
-            expect(value).to.deep.equal([false, true]);
+            const lastCall = value.slice(-1)[0];
+            expect(lastCall).to.equal(true);
           });
         });
       });
@@ -286,12 +354,13 @@ describe('<BusinessInformationWizardStep />', () => {
           cy.get("#business").should("be.visible").shadow().find("input").type("Valid");
           cy.wait("@searchCompany");
 
-          cy.get('cds-combo-box-item[data-id="XX9016140"]').click();
+          cy.get("cds-combo-box-item[data-id='XX9016140']").click();
         });
         it("should re-check individual validation", () => {
           cy.wait("@checkIndividualElse");
           cy.wrap(callsSetIndividualValid).should((value) => {
-            expect(value).to.deep.equal([false, true]);
+            const lastCall = value.slice(-1)[0];
+            expect(lastCall).to.equal(true);
           });
         });
       });
@@ -339,12 +408,13 @@ describe('<BusinessInformationWizardStep />', () => {
             cy.get("#business").should("be.visible").shadow().find("input").type("Valid");
             cy.wait("@searchCompany");
 
-            cy.get('cds-combo-box-item[data-id="XX9016140"]').click();
+            cy.get("cds-combo-box-item[data-id='XX9016140']").click();
           });
           it("should re-check individual validation", () => {
             cy.wait("@checkIndividualElse");
             cy.wrap(callsSetIndividualValid).should((value) => {
-              expect(value).to.deep.equal([false, true]);
+              const lastCall = value.slice(-1)[0];
+              expect(lastCall).to.equal(true);
             });
           });
         });

--- a/frontend/tests/pages/bceid/BusinessInformationWizardStep.cy.ts
+++ b/frontend/tests/pages/bceid/BusinessInformationWizardStep.cy.ts
@@ -119,7 +119,6 @@ describe('<BusinessInformationWizardStep />', () => {
             goodStandingInd: "",
             birthdate: "",
             address: "",
-            district: "DMH",
           },
           location: {
             contacts: [

--- a/frontend/tests/pages/bceid/BusinessInformationWizardStep.cy.ts
+++ b/frontend/tests/pages/bceid/BusinessInformationWizardStep.cy.ts
@@ -228,15 +228,15 @@ describe('<BusinessInformationWizardStep />', () => {
   });
 
   describe("when a Registered individual business gets selected", () => {
-    let callsSetIndividualValid = [];
+    let callsSetIndividualValidInd = [];
     const functionWrapper = {
-      setIndividualValid: (value: boolean) => {
-        callsSetIndividualValid.push(value);
+      setIndividualValidInd: (value: boolean) => {
+        callsSetIndividualValidInd.push(value);
       },
     };
-    const { setIndividualValid } = functionWrapper;
+    const { setIndividualValidInd } = functionWrapper;
     beforeEach(() => {
-      callsSetIndividualValid = [];
+      callsSetIndividualValidInd = [];
       cy.mount(BusinessInformationWizardStep, {
         props: {
           data: {
@@ -261,8 +261,8 @@ describe('<BusinessInformationWizardStep />', () => {
           } as unknown as FormDataDto,
           districtsList: districts,
           active: false,
-          individualValid: false,
-          setIndividualValid,
+          individualValidInd: false,
+          setIndividualValidInd,
         },
         global,
       });
@@ -273,7 +273,7 @@ describe('<BusinessInformationWizardStep />', () => {
       cy.wait("@searchCompany");
 
       cy.get("cds-combo-box-item[data-id='XX9016140']").click();
-      cy.wrap(callsSetIndividualValid).should((value) => {
+      cy.wrap(callsSetIndividualValidInd).should((value) => {
         const lastCall = value.slice(-1)[0];
         expect(lastCall).to.equal(true);
       });
@@ -281,12 +281,12 @@ describe('<BusinessInformationWizardStep />', () => {
 
     describe("and type of business is changed to Unregistered", () => {
       beforeEach(() => {
-        callsSetIndividualValid = [];
+        callsSetIndividualValidInd = [];
         cy.get("#businessTyperbU").click();
       })
       it("should re-check with user's last name", () => {
         cy.wait("@checkIndividualUser");
-        cy.wrap(callsSetIndividualValid).should((value) => {
+        cy.wrap(callsSetIndividualValidInd).should((value) => {
           const lastCall = value.slice(-1)[0];
           expect(lastCall).to.equal(true);
         });
@@ -295,17 +295,17 @@ describe('<BusinessInformationWizardStep />', () => {
   });
 
   describe("when props.individualValue is true", () => {
-    const individualValid = true;
-    let callsSetIndividualValid = [];
+    const individualValidInd = true;
+    let callsSetIndividualValidInd = [];
     const functionWrapper = {
-      setIndividualValid: (value: boolean) => {
-        callsSetIndividualValid.push(value);
+      setIndividualValidInd: (value: boolean) => {
+        callsSetIndividualValidInd.push(value);
       },
     };
-    const { setIndividualValid } = functionWrapper;
+    const { setIndividualValidInd } = functionWrapper;
     describe("and type of business is Registered", () => {
       beforeEach(() => {
-        callsSetIndividualValid = [];
+        callsSetIndividualValidInd = [];
         cy.mount(BusinessInformationWizardStep, {
           props: {
             data: {
@@ -330,8 +330,8 @@ describe('<BusinessInformationWizardStep />', () => {
             } as unknown as FormDataDto,
             districtsList: districts,
             active: false,
-            individualValid,
-            setIndividualValid,
+            individualValidInd,
+            setIndividualValidInd,
           },
           global,
         });
@@ -342,7 +342,7 @@ describe('<BusinessInformationWizardStep />', () => {
         })
         it("should re-check individual validation", () => {
           cy.wait("@checkIndividualUser");
-          cy.wrap(callsSetIndividualValid).should((value) => {
+          cy.wrap(callsSetIndividualValidInd).should((value) => {
             const lastCall = value.slice(-1)[0];
             expect(lastCall).to.equal(true);
           });
@@ -357,7 +357,7 @@ describe('<BusinessInformationWizardStep />', () => {
         });
         it("should re-check individual validation", () => {
           cy.wait("@checkIndividualElse");
-          cy.wrap(callsSetIndividualValid).should((value) => {
+          cy.wrap(callsSetIndividualValidInd).should((value) => {
             const lastCall = value.slice(-1)[0];
             expect(lastCall).to.equal(true);
           });
@@ -367,7 +367,7 @@ describe('<BusinessInformationWizardStep />', () => {
 
     describe("and type of business is Unregistered", () => {
       beforeEach(() => {
-        callsSetIndividualValid = [];
+        callsSetIndividualValidInd = [];
         cy.mount(BusinessInformationWizardStep, {
           props: {
             data: {
@@ -392,8 +392,8 @@ describe('<BusinessInformationWizardStep />', () => {
             } as unknown as FormDataDto,
             districtsList: districts,
             active: false,
-            individualValid,
-            setIndividualValid,
+            individualValidInd,
+            setIndividualValidInd,
           },
           global,
         });
@@ -411,7 +411,7 @@ describe('<BusinessInformationWizardStep />', () => {
           });
           it("should re-check individual validation", () => {
             cy.wait("@checkIndividualElse");
-            cy.wrap(callsSetIndividualValid).should((value) => {
+            cy.wrap(callsSetIndividualValidInd).should((value) => {
               const lastCall = value.slice(-1)[0];
               expect(lastCall).to.equal(true);
             });

--- a/frontend/tests/pages/bceid/BusinessInformationWizardStep.cy.ts
+++ b/frontend/tests/pages/bceid/BusinessInformationWizardStep.cy.ts
@@ -73,7 +73,7 @@ describe('<BusinessInformationWizardStep />', () => {
     }).as("checkIndividualUser");
 
     cy.intercept("GET", "/api/clients/individual/mockUserId?lastName=Else", {
-      statusCode: 404,
+      statusCode: 200,
       delay: 10,
     }).as("checkIndividualElse");
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Remembers the status of individual validation so the button Next stays enabled when the user goes back to step 1.
Also makes sure it gets revalidated if a different individual business gets selected or type of business is changed to Unregistered.

Fixes [FSADT1-1283](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT1-1283)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-7-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)