### PR TITLE
fix(fe:FSADT1-1406): Changed the logic when the good standing indicat…

### DIFF
--- a/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
+++ b/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
@@ -284,10 +284,10 @@ watch([detailsData], () => {
     );
 
     formData.value.businessInformation.goodStandingInd =
-      (forestClientDetails.goodStanding ?? false) ? "Y" : "N";
-
+      (forestClientDetails.goodStanding ?? true) ? "Y" : "N";
+    
     toggleErrorMessages(
-      (forestClientDetails.goodStanding ?? false) ? false : true,
+      (forestClientDetails.goodStanding ?? true) ? false : true,
       null
     );
 


### PR DESCRIPTION
Changed the logic when the good standing indicator is null

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-30-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)