### PR TITLE
fix(fe:FSADT1-1423): Hide left menu when the user is at the confirmat…

### DIFF
--- a/frontend/src/components/MainHeaderComponent.vue
+++ b/frontend/src/components/MainHeaderComponent.vue
@@ -224,8 +224,10 @@ const userHasAuthority = ["CLIENT_EDITOR", "CLIENT_ADMIN"].some(authority => For
       @click.prevent="myProfileAction?.click"
     ></div>
   </cds-header>
-
-  <cds-side-nav v-if="$route.meta.sideMenu" v-shadow=1>
+  
+  <cds-side-nav 
+    v-if="$route.meta.sideMenu && $route.name != 'staff-confirmation'" 
+    v-shadow=1>
     <cds-side-nav-items v-shadow=1>      
       <cds-side-nav-link 
         :active="$route.name == 'internal'" 

--- a/frontend/src/components/MainHeaderComponent.vue
+++ b/frontend/src/components/MainHeaderComponent.vue
@@ -224,9 +224,9 @@ const userHasAuthority = ["CLIENT_EDITOR", "CLIENT_ADMIN"].some(authority => For
       @click.prevent="myProfileAction?.click"
     ></div>
   </cds-header>
-  
+
   <cds-side-nav 
-    v-if="$route.meta.sideMenu && $route.name != 'staff-confirmation'" 
+    v-if="$route.meta.sideMenu" 
     v-shadow=1>
     <cds-side-nav-items v-shadow=1>      
       <cds-side-nav-link 

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -132,7 +132,7 @@ export const routes = [
       },
       style: "content",
       headersStyle: "headers",
-      sideMenu: true,
+      sideMenu: false,
       profile: true,
     },
   },


### PR DESCRIPTION
fix(fe:FSADT1-1423): Hide left menu when the user is at the confirmation page

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-7-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)