### PR TITLE
fix(fe:FSADT1-1427): Fixed issue with autocomplete emitting value twice

### DIFF
--- a/frontend/src/components/forms/AutoCompleteInputComponent.vue
+++ b/frontend/src/components/forms/AutoCompleteInputComponent.vue
@@ -95,8 +95,11 @@ const emitValueChange = (newValue: string): void => {
   // Prevent selecting the empty value included when props.contents is empty.
   selectedValue = newValue ? inputList.value.find((entry) => entry.code === newValue) : undefined;
 
-  emit("update:model-value", selectedValue?.name ?? newValue);
-  emit("update:selected-value", selectedValue);
+  if (selectedValue) {
+    emit("update:model-value", selectedValue?.name ?? newValue);
+    emit("update:selected-value", selectedValue);
+  }
+
   emit("empty", isEmpty(newValue));
 };
 
@@ -106,21 +109,25 @@ const isUserEvent = ref(false);
 const userValue = ref("");
 
 const cdsComboBoxRef = ref<InstanceType<typeof CDSComboBox> | null>(null);
+
 watch(
   () => props.modelValue,
-  () => {
-    inputValue.value = props.modelValue;
-    if (!isUserEvent.value && cdsComboBoxRef.value) {
-      cdsComboBoxRef.value._filterInputValue = props.modelValue || "";
-
-      // Validate the SELECTED value immediately.
-      validateInput(props.modelValue);
+  (newValue, oldValue) => {
+    if (newValue !== oldValue) {
+      inputValue.value = newValue;
+      if (!isUserEvent.value && cdsComboBoxRef.value) {
+        cdsComboBoxRef.value._filterInputValue = newValue || "";
+        validateInput(newValue);
+      }
+      isUserEvent.value = false;
     }
-    isUserEvent.value = false;
   },
 );
-watch([inputValue], () => {
-  emitValueChange(inputValue.value);
+
+watch([inputValue], (newValue, oldValue) => {
+  if (newValue !== oldValue) {
+    emitValueChange(inputValue.value);
+  }
 });
 
 const setError = (errorMessage: string | undefined) => {


### PR DESCRIPTION
Fixed issue with autocomplete emitting value twice

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-12-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)