### PR TITLE
fix(FSADT1-1435): fixing validation during onnext

### DIFF
--- a/frontend/src/components/forms/AutoCompleteInputComponent.vue
+++ b/frontend/src/components/forms/AutoCompleteInputComponent.vue
@@ -42,7 +42,7 @@ const emit = defineEmits<{
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<void>("revalidate-bus");
+const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
 
 const warning = ref(false);
 
@@ -179,7 +179,11 @@ const onTyping = (event: any) => {
   emit("update:model-value", inputValue.value);
 };
 
-revalidateBus.on(() => validateInput(inputValue.value));
+revalidateBus.on((keys: string[] | undefined) => {
+  if(keys === undefined || keys.includes(props.id)) {
+    validateInput(inputValue.value)
+  }
+});
 
 /*
 By applying a suffix which is impossible to be typed to the items' names, the search input will

--- a/frontend/src/components/forms/AutoCompleteInputComponent.vue
+++ b/frontend/src/components/forms/AutoCompleteInputComponent.vue
@@ -180,7 +180,7 @@ const onTyping = (event: any) => {
 };
 
 revalidateBus.on((keys: string[] | undefined) => {
-  if(keys === undefined || keys.includes(props.id)) {
+  if (keys === undefined || keys.includes(props.id)) {
     validateInput(inputValue.value)
   }
 });

--- a/frontend/src/components/forms/AutoCompleteInputComponent.vue
+++ b/frontend/src/components/forms/AutoCompleteInputComponent.vue
@@ -220,8 +220,9 @@ watch(
 
       const helperTextId = "helper-text";
       const helperText = cdsComboBox.shadowRoot?.querySelector(
-        "[name='helper-text']
+        "[name='helper-text']"
       );
+      
       if (helperText) {
         helperText.id = helperTextId;
 

--- a/frontend/src/components/forms/AutoCompleteInputComponent.vue
+++ b/frontend/src/components/forms/AutoCompleteInputComponent.vue
@@ -11,7 +11,8 @@ import type { BusinessSearchResult, CodeNameType } from "@/dto/CommonTypesDto";
 import { isEmpty, type ValidationMessageType } from "@/dto/CommonTypesDto";
 
 //Define the input properties for this component
-const props = withDefaults(defineProps<{
+const props = withDefaults(
+  defineProps<{
     id: string;
     label: string;
     tip?: string;
@@ -28,7 +29,7 @@ const props = withDefaults(defineProps<{
   }>(),
   {
     showLoadingAfterTime: 2000,
-  },
+  }
 );
 
 //Events we emit during component lifecycle
@@ -42,19 +43,19 @@ const emit = defineEmits<{
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
+const revalidateBus = useEventBus<string[] | undefined>("revalidate-bus");
 
 const warning = ref(false);
 
 watch(
   () => props.errorMessage,
-  () => setError(props.errorMessage),
+  () => setError(props.errorMessage)
 );
 
 //We set the value prop as a reference for update reason
 const inputValue = ref(props.modelValue);
 
-const LOADING_NAME = "loading...";
+const loadingName = "loading...";
 
 const showLoadingTimer = ref<number>();
 
@@ -72,8 +73,8 @@ watch(
         showLoading.value = true;
       }, props.showLoadingAfterTime);
     }
-  },
-)
+  }
+);
 
 // This is to make the input list contains the selected value to show when component render
 const inputList = computed<Array<BusinessSearchResult>>(() => {
@@ -81,10 +82,10 @@ const inputList = computed<Array<BusinessSearchResult>>(() => {
     return props.contents.filter((entry) => entry.name);
   } else if (props.modelValue !== userValue.value) {
     // Needed when the component mounts with a pre-filled value.
-    return [{ name: props.modelValue, code: "", status: "", legalType: "" }]
+    return [{ name: props.modelValue, code: "", status: "", legalType: "" }];
   } else if (props.modelValue && showLoading.value) {
     // Just to give a "loading" feedback.
-    return [{ name: LOADING_NAME, code: "", status: "", legalType: "" }];
+    return [{ name: loadingName, code: "", status: "", legalType: "" }];
   }
   return [];
 });
@@ -93,9 +94,10 @@ let selectedValue: BusinessSearchResult | undefined = undefined;
 
 //This function emits the events on update
 const emitValueChange = (newValue: string): void => {
-
   // Prevent selecting the empty value included when props.contents is empty.
-  selectedValue = newValue ? inputList.value.find((entry) => entry.code === newValue) : undefined;
+  selectedValue = newValue
+    ? inputList.value.find((entry) => entry.code === newValue)
+    : undefined;
 
   emit("update:model-value", selectedValue?.name ?? newValue);
   emit("update:selected-value", selectedValue);
@@ -119,7 +121,7 @@ watch(
       validateInput(props.modelValue);
     }
     isUserEvent.value = false;
-  },
+  }
 );
 watch([inputValue], () => {
   emitValueChange(inputValue.value);
@@ -130,7 +132,8 @@ watch([inputValue], () => {
  * @param errorObject - the error object or string
  */
 const setError = (errorObject: string | ValidationMessageType | undefined) => {
-  const errorMessage = typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
+  const errorMessage =
+    typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
   error.value = errorMessage || "";
 
   warning.value = false;
@@ -145,8 +148,8 @@ const setError = (errorObject: string | ValidationMessageType | undefined) => {
   rely on empty(false) to consider a value "valid". In turn we need to emit a new error event after
   an empty one to allow subscribers to know in case the field still has the same error.
   */
-  emit('error', error.value);
-}
+  emit("error", error.value);
+};
 
 //We call all the validations
 const validateInput = (newValue: string) => {
@@ -158,10 +161,7 @@ const validateInput = (newValue: string) => {
           if (errorMessage) return true;
           return false;
         })
-        .reduce(
-          (acc, errorMessage) => acc || errorMessage,
-          props.errorMessage,
-        )
+        .reduce((acc, errorMessage) => acc || errorMessage, props.errorMessage)
     );
   }
 };
@@ -181,7 +181,7 @@ const onTyping = (event: any) => {
 
 revalidateBus.on((keys: string[] | undefined) => {
   if (keys === undefined || keys.includes(props.id)) {
-    validateInput(inputValue.value)
+    validateInput(inputValue.value);
   }
 });
 
@@ -199,20 +199,29 @@ const nameSuffix = "\0";
 By checking the item has a code, we know this is a real option instead of a mock one.
 We need the mock one (with no suffix) when the component mounts with a pre-filled value.
 */
-const getComboBoxItemValue = (item: CodeNameType) => item.name + (item.code ? nameSuffix : "");
+const getComboBoxItemValue = (item: CodeNameType) =>
+  item.name + (item.code ? nameSuffix : "");
 
 const ariaInvalidString = computed(() => (error.value ? "true" : "false"));
 const isFocused = ref(false);
 
 watch(
-  [cdsComboBoxRef, () => props.required, () => props.label, isFocused, ariaInvalidString],
+  [
+    cdsComboBoxRef,
+    () => props.required,
+    () => props.label,
+    isFocused,
+    ariaInvalidString,
+  ],
   async ([cdsComboBox]) => {
     if (cdsComboBox) {
       // wait for the DOM updates to complete
       await nextTick();
 
       const helperTextId = "helper-text";
-      const helperText = cdsComboBox.shadowRoot?.querySelector("[name='helper-text']");
+      const helperText = cdsComboBox.shadowRoot?.querySelector(
+        "[name='helper-text']
+      );
       if (helperText) {
         helperText.id = helperTextId;
 
@@ -220,7 +229,8 @@ watch(
         if (isFocused.value) {
           helperText.role = "generic";
         } else {
-          helperText.role = ariaInvalidString.value === "true" ? "alert" : "generic";
+          helperText.role =
+            ariaInvalidString.value === "true" ? "alert" : "generic";
         }
       }
 
@@ -235,7 +245,7 @@ watch(
         input.setAttribute("aria-describedby", helperTextId);
       }
     }
-  },
+  }
 );
 
 // For some reason, if helper-text is empty, invalid-text message doesn't work.
@@ -285,9 +295,9 @@ const safeHelperText = computed(() => props.tip || " ");
           :data-value="item.name"
           :value="getComboBoxItemValue(item)"
           v-shadow
-          :data-loading="item.name === LOADING_NAME"
+          :data-loading="item.name === loadingName"
         >
-          <template v-if="item.name === LOADING_NAME">
+          <template v-if="item.name === loadingName">
             <cds-inline-loading />
           </template>
           <template v-else>

--- a/frontend/src/components/forms/DateInputComponent/index.vue
+++ b/frontend/src/components/forms/DateInputComponent/index.vue
@@ -51,7 +51,7 @@ const props = withDefaults(
     yearValidations: () => [],
     monthValidations: () => [],
     dayValidations: () => [],
-  },
+  }
 );
 
 // Events we emit during component lifecycle
@@ -79,7 +79,7 @@ const emit = defineEmits<{
 // We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
+const revalidateBus = useEventBus<string[] | undefined>("revalidate-bus");
 
 const partError = reactive({
   [DatePart.year]: "",
@@ -95,7 +95,10 @@ const warning = ref(false);
  * Sets the error and emits an error event.
  * @param errorObject - the error object or string
  */
-const setError = (errorObject: string | ValidationMessageType | undefined, datePart?: DatePart) => {
+const setError = (
+  errorObject: string | ValidationMessageType | undefined,
+  datePart?: DatePart
+) => {
   /*
   The error should be emitted whenever it is found, instead of watching and emitting only when it
   changes.
@@ -104,7 +107,8 @@ const setError = (errorObject: string | ValidationMessageType | undefined, dateP
   an empty one to allow subscribers to know in case the field still has the same error.
   */
 
-  const errorMessage = typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
+  const errorMessage =
+    typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
 
   warning.value = false;
   if (typeof errorObject === "object") {
@@ -124,7 +128,9 @@ const setError = (errorObject: string | ValidationMessageType | undefined, dateP
       other part contains error.
       */
       const newErrorMessage =
-        partError[DatePart.year] || partError[DatePart.month] || partError[DatePart.day];
+        partError[DatePart.year] ||
+        partError[DatePart.month] ||
+        partError[DatePart.day];
       error.value = newErrorMessage;
     } else {
       error.value = errorMessage;
@@ -147,8 +153,8 @@ const setError = (errorObject: string | ValidationMessageType | undefined, dateP
 
 watch(
   () => props.errorMessage,
-  () => setError(props.errorMessage),
-)
+  () => setError(props.errorMessage)
+);
 
 const datePartPositions = {
   [DatePart.year]: 1,
@@ -159,7 +165,9 @@ const datePartPositions = {
 const regex = /(.{0,4})-(.{0,2})-(.{0,2})/;
 
 const getDatePart = (datePart: DatePart) =>
-  props.modelValue ? regex.exec(props.modelValue)[datePartPositions[datePart]] : "";
+  props.modelValue
+    ? regex.exec(props.modelValue)[datePartPositions[datePart]]
+    : "";
 
 // We set it as a separated ref due to props not being updatable
 const selectedValue = ref<string | null>(props.modelValue);
@@ -168,13 +176,18 @@ const selectedYear = ref<string>(getDatePart(DatePart.year));
 const selectedMonth = ref<string>(getDatePart(DatePart.month));
 const selectedDay = ref<string>(getDatePart(DatePart.day));
 
-const buildFullDate = () => `${selectedYear.value}-${selectedMonth.value}-${selectedDay.value}`
+const buildFullDate = () =>
+  `${selectedYear.value}-${selectedMonth.value}-${selectedDay.value}`;
 
 const areAllPartsValid = () =>
-  validation[DatePart.year] && validation[DatePart.month] && validation[DatePart.day];
+  validation[DatePart.year] &&
+  validation[DatePart.month] &&
+  validation[DatePart.day];
 
 const isAnyPartEmpty = () =>
-  isEmpty(selectedYear.value) || isEmpty(selectedMonth.value) || isEmpty(selectedDay.value);
+  isEmpty(selectedYear.value) ||
+  isEmpty(selectedMonth.value) ||
+  isEmpty(selectedDay.value);
 
 // We set the value prop as a reference for update reason
 emit("empty", isAnyPartEmpty());
@@ -204,7 +217,7 @@ const emitValueChange = (newValue: string): void => {
 
 // Watch for changes on the input
 watch([selectedValue], () => {
-  emitValueChange(selectedValue.value)
+  emitValueChange(selectedValue.value);
 });
 
 // We call all the part validations
@@ -213,8 +226,8 @@ const validatePart = (datePart: DatePart) => {
   const error = partValidators.value[datePart]
     .map((validation) => validation(newValue))
     .filter((errorMessage) => {
-      if (errorMessage) return true
-      return false
+      if (errorMessage) return true;
+      return false;
     })
     .shift();
   setError(error, datePart);
@@ -228,8 +241,8 @@ const validateFullDate = (newValue: string) => {
       props.validations
         .map((validation) => validation(newValue))
         .filter((errorMessage) => {
-          if (errorMessage) return true
-          return false
+          if (errorMessage) return true;
+          return false;
         })
         .shift() ?? props.errorMessage;
     setError(error);
@@ -253,7 +266,8 @@ const validation = reactive({
 const validationFullDate = ref(false);
 
 const year4DigitsMessage = "Year must have 4 digits";
-const month2DigitsMessage = "Month must have 2 digits. For example, 01 for January";
+const month2DigitsMessage =
+  "Month must have 2 digits. For example, 01 for January";
 const day2DigitsMessage = "Day must have 2 digits";
 
 const partValidators = computed(() => ({
@@ -282,11 +296,13 @@ const partValidators = computed(() => ({
       if (!validation[DatePart.year] || !validation[DatePart.month]) {
         return "";
       }
-      const yearMonthDate = parseISO(`${selectedYear.value}-${selectedMonth.value}`);
+      const yearMonthDate = parseISO(
+        `${selectedYear.value}-${selectedMonth.value}`
+      );
       return isValidDayOfMonthYear(
         selectedYear.value,
         selectedMonth.value,
-        `Day can't be greater than ${getDaysInMonth(yearMonthDate)}`,
+        `Day can't be greater than ${getDaysInMonth(yearMonthDate)}`
       )(value);
     },
     (value: string) => {
@@ -294,11 +310,13 @@ const partValidators = computed(() => ({
         return "";
       }
       const arbitraryLeapYear = 2000;
-      const yearMonthDate = parseISO(`${arbitraryLeapYear}-${selectedMonth.value}`);
+      const yearMonthDate = parseISO(
+        `${arbitraryLeapYear}-${selectedMonth.value}`
+      );
       return isValidDayOfMonth(
         selectedMonth.value,
-        `Day can't be greater than ${getDaysInMonth(yearMonthDate)}`,
-      )(value)
+        `Day can't be greater than ${getDaysInMonth(yearMonthDate)}`
+      )(value);
     },
     isLessThan(32, "Day can't be greater than 31"),
     ...props.dayValidations,
@@ -365,13 +383,13 @@ watch(
       selectedValue.value = props.modelValue;
 
       if (areAllPartsValid()) {
-        validateFullDate(selectedValue.value)
+        validateFullDate(selectedValue.value);
       }
     }
 
     // resets variable
     isUserEvent.value = false;
-  },
+  }
 );
 
 // Tells whether the current change was done manually by the user.

--- a/frontend/src/components/forms/DateInputComponent/index.vue
+++ b/frontend/src/components/forms/DateInputComponent/index.vue
@@ -79,7 +79,7 @@ const emit = defineEmits<{
 // We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<void>("revalidate-bus");
+const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
 
 const partError = reactive({
   [DatePart.year]: "",
@@ -339,11 +339,13 @@ const onBlurYear = onBlurPart(DatePart.year);
 const onBlurMonth = onBlurPart(DatePart.month);
 const onBlurDay = onBlurPart(DatePart.day);
 
-revalidateBus.on(() => {
-  validation[DatePart.year] = validatePart(DatePart.year);
-  validation[DatePart.month] = validatePart(DatePart.month);
-  validation[DatePart.day] = validatePart(DatePart.day);
-  validateFullDate(selectedValue.value);
+revalidateBus.on((keys: string[] | undefined) => {
+  if(keys === undefined || keys.includes(props.id)) {
+    validation[DatePart.year] = validatePart(DatePart.year);
+    validation[DatePart.month] = validatePart(DatePart.month);
+    validation[DatePart.day] = validatePart(DatePart.day);
+    validateFullDate(selectedValue.value);
+  }
 });
 
 watch(

--- a/frontend/src/components/forms/DateInputComponent/index.vue
+++ b/frontend/src/components/forms/DateInputComponent/index.vue
@@ -340,7 +340,7 @@ const onBlurMonth = onBlurPart(DatePart.month);
 const onBlurDay = onBlurPart(DatePart.day);
 
 revalidateBus.on((keys: string[] | undefined) => {
-  if(keys === undefined || keys.includes(props.id)) {
+  if (keys === undefined || keys.includes(props.id)) {
     validation[DatePart.year] = validatePart(DatePart.year);
     validation[DatePart.month] = validatePart(DatePart.month);
     validation[DatePart.day] = validatePart(DatePart.day);

--- a/frontend/src/components/forms/DropdownInputComponent.vue
+++ b/frontend/src/components/forms/DropdownInputComponent.vue
@@ -35,7 +35,7 @@ const emit = defineEmits<{
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
+const revalidateBus = useEventBus<string[] | undefined>("revalidate-bus");
 
 const warning = ref(false);
 
@@ -54,20 +54,20 @@ emit("empty", isEmpty(props.initialValue));
 const emitValueChange = (newValue: string): void => {
   const reference = newValue
     ? props.modelValue.find((entry) => entry.name === newValue)
-    : { code: '', name: '' };
+    : { code: "", name: "" };
 
   emit("update:modelValue", reference?.name);
   emit("update:selectedValue", reference);
   emit("empty", isEmpty(newValue));
 };
 
-
 /**
  * Sets the error and emits an error event.
  * @param errorObject - the error object or string
  */
 const setError = (errorObject: string | ValidationMessageType | undefined) => {
-  const errorMessage = typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
+  const errorMessage =
+    typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
   error.value = errorMessage || "";
 
   warning.value = false;
@@ -82,8 +82,8 @@ const setError = (errorObject: string | ValidationMessageType | undefined) => {
   rely on empty(false) to consider a value "valid". In turn we need to emit a new error event after
   an empty one to allow subscribers to know in case the field still has the same error.
   */
-  emit('error', error.value);
-}
+  emit("error", error.value);
+};
 
 /**
  * Performs all validations and returns the first error message.
@@ -94,20 +94,15 @@ const setError = (errorObject: string | ValidationMessageType | undefined) => {
  */
 const validatePurely = (newValue: string): string | undefined => {
   if (props.validations) {
-    return (
-      props.validations
-        .map((validation) => validation(newValue))
-        .filter((errorMessage) => {
-          if (errorMessage) return true;
-          return false;
-        })
-        .reduce(
-          (acc, errorMessage) => acc || errorMessage,
-          props.errorMessage
-        )
-    );
+    return props.validations
+      .map((validation) => validation(newValue))
+      .filter((errorMessage) => {
+        if (errorMessage) return true;
+        return false;
+      })
+      .reduce((acc, errorMessage) => acc || errorMessage, props.errorMessage);
   }
-}
+};
 
 const validateInput = (newValue: any) => {
   if (props.validations) {
@@ -116,11 +111,11 @@ const validateInput = (newValue: any) => {
 };
 
 // Tells whether the current change was done manually by the user.
-const isUserEvent = ref(false)
+const isUserEvent = ref(false);
 
 const selectItem = (event: any) => {
   selectedValue.value = event?.detail?.item?.getAttribute("data-value");
-  isUserEvent.value = true
+  isUserEvent.value = true;
 };
 
 /**
@@ -173,7 +168,7 @@ watch(
 
 revalidateBus.on((keys: string[] | undefined) => {
   if (keys === undefined || keys.includes(props.id)) {
-    validateInput(selectedValue.value)
+    validateInput(selectedValue.value);
   }
 });
 
@@ -182,10 +177,18 @@ const ariaInvalidString = computed(() => (error.value ? "true" : "false"));
 const isFocused = ref(false);
 
 // This is an array due to the v-for attribute.
-const cdsComboBoxArrayRef = ref<InstanceType<typeof CDSComboBox>[] | null>(null);
+const cdsComboBoxArrayRef = ref<InstanceType<typeof CDSComboBox>[] | null>(
+  null
+);
 
 watch(
-  [cdsComboBoxArrayRef, () => props.required, () => props.label, isFocused, ariaInvalidString],
+  [
+    cdsComboBoxArrayRef,
+    () => props.required,
+    () => props.label,
+    isFocused,
+    ariaInvalidString,
+  ],
   async ([cdsComboBoxArray]) => {
     if (cdsComboBoxArray) {
       // wait for the DOM updates to complete
@@ -195,7 +198,9 @@ watch(
       const input = combo?.shadowRoot?.querySelector("input");
 
       const helperTextId = "helper-text";
-      const helperText = combo.shadowRoot?.querySelector("[name='helper-text']");
+      const helperText = combo.shadowRoot?.querySelector(
+        "[name='helper-text']"
+      );
       if (helperText) {
         helperText.id = helperTextId;
 
@@ -203,7 +208,8 @@ watch(
         if (isFocused.value) {
           helperText.role = "generic";
         } else {
-          helperText.role = ariaInvalidString.value === "true" ? "alert" : "generic";
+          helperText.role =
+            ariaInvalidString.value === "true" ? "alert" : "generic";
         }
       }
 
@@ -217,7 +223,7 @@ watch(
         input.setAttribute("aria-describedby", helperTextId);
       }
     }
-  },
+  }
 );
 
 // For some reason, if helper-text is empty, invalid-text message doesn't work.

--- a/frontend/src/components/forms/DropdownInputComponent.vue
+++ b/frontend/src/components/forms/DropdownInputComponent.vue
@@ -35,7 +35,7 @@ const emit = defineEmits<{
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<void>("revalidate-bus");
+const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
 
 const warning = ref(false);
 
@@ -171,7 +171,11 @@ watch(
   () => (selectedValue.value = props.initialValue)
 );
 
-revalidateBus.on(() => validateInput(selectedValue.value));
+revalidateBus.on((keys: string[] | undefined) => {
+  if(keys === undefined || keys.includes(props.id)) {
+    validateInput(selectedValue.value)
+  }
+});
 
 const ariaInvalidString = computed(() => (error.value ? "true" : "false"));
 

--- a/frontend/src/components/forms/DropdownInputComponent.vue
+++ b/frontend/src/components/forms/DropdownInputComponent.vue
@@ -172,7 +172,7 @@ watch(
 );
 
 revalidateBus.on((keys: string[] | undefined) => {
-  if(keys === undefined || keys.includes(props.id)) {
+  if (keys === undefined || keys.includes(props.id)) {
     validateInput(selectedValue.value)
   }
 });

--- a/frontend/src/components/forms/MultiselectInputComponent.vue
+++ b/frontend/src/components/forms/MultiselectInputComponent.vue
@@ -140,7 +140,7 @@ watch(
 );
 
 revalidateBus.on((keys: string[] | undefined) => {
-  if(keys === undefined || keys.includes(props.id)) {
+  if (keys === undefined || keys.includes(props.id)) {
     validateInput(selectedValue.value)
   }
 });

--- a/frontend/src/components/forms/MultiselectInputComponent.vue
+++ b/frontend/src/components/forms/MultiselectInputComponent.vue
@@ -34,7 +34,7 @@ const emit = defineEmits<{
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<void>("revalidate-bus");
+const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
 
 const warning = ref(false);
 
@@ -139,7 +139,11 @@ watch(
   () => setError(props.errorMessage)
 );
 
-revalidateBus.on(() => validateInput(selectedValue.value));
+revalidateBus.on((keys: string[] | undefined) => {
+  if(keys === undefined || keys.includes(props.id)) {
+    validateInput(selectedValue.value)
+  }
+});
 
 const ariaInvalidString = computed(() => (error.value ? "true" : "false"));
 

--- a/frontend/src/components/forms/MultiselectInputComponent.vue
+++ b/frontend/src/components/forms/MultiselectInputComponent.vue
@@ -34,7 +34,7 @@ const emit = defineEmits<{
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
+const revalidateBus = useEventBus<string[] | undefined>("revalidate-bus");
 
 const warning = ref(false);
 
@@ -58,7 +58,8 @@ const items = ref<string[]>([]);
  * @param errorObject - the error object or string
  */
 const setError = (errorObject: string | ValidationMessageType | undefined) => {
-  const errorMessage = typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
+  const errorMessage =
+    typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
   error.value = errorMessage || "";
 
   warning.value = false;
@@ -73,8 +74,8 @@ const setError = (errorObject: string | ValidationMessageType | undefined) => {
   rely on empty(false) to consider a value "valid". In turn we need to emit a new error event after
   an empty one to allow subscribers to know in case the field still has the same error.
   */
-  emit('error', error.value);
-}
+  emit("error", error.value);
+};
 
 //We call all the validations
 const validateInput = (newValue: any) => {
@@ -87,10 +88,7 @@ const validateInput = (newValue: any) => {
       props.validations
         .map((validation) => validation(value))
         .filter(hasError)
-        .reduce(
-          (acc, errorMessage) => acc || errorMessage,
-          props.errorMessage
-        );
+        .reduce((acc, errorMessage) => acc || errorMessage, props.errorMessage);
 
     setError(validate(items.value));
   }
@@ -141,7 +139,7 @@ watch(
 
 revalidateBus.on((keys: string[] | undefined) => {
   if (keys === undefined || keys.includes(props.id)) {
-    validateInput(selectedValue.value)
+    validateInput(selectedValue.value);
   }
 });
 
@@ -159,7 +157,9 @@ watch(
       await nextTick();
 
       const helperTextId = "helper-text";
-      const helperText = cdsMultiSelect.shadowRoot?.querySelector("[name='helper-text']");
+      const helperText = cdsMultiSelect.shadowRoot?.querySelector(
+        "[name='helper-text']"
+      );
       if (helperText) {
         helperText.id = helperTextId;
 
@@ -167,11 +167,13 @@ watch(
         if (isFocused.value) {
           helperText.role = "generic";
         } else {
-          helperText.role = ariaInvalidString.value === "true" ? "alert" : "generic";
+          helperText.role =
+            ariaInvalidString.value === "true" ? "alert" : "generic";
         }
       }
 
       const triggerDiv = cdsMultiSelect.shadowRoot?.querySelector("div[role='button']");
+      
       if (triggerDiv) {
         // Properly indicate as required.
         triggerDiv.ariaRequired = props.required ? "true" : "false";
@@ -181,7 +183,7 @@ watch(
         triggerDiv.setAttribute("aria-describedby", helperTextId);
       }
     }
-  },
+  }
 );
 </script>
 

--- a/frontend/src/components/forms/RadioInputComponent.vue
+++ b/frontend/src/components/forms/RadioInputComponent.vue
@@ -2,7 +2,10 @@
 import { ref, watch, nextTick, computed } from "vue";
 // Carbon
 import "@carbon/web-components/es/components/radio-button/index";
-import type { CDSRadioButtonGroup, CDSRadioButton } from "@carbon/web-components";
+import type {
+  CDSRadioButtonGroup,
+  CDSRadioButton,
+} from "@carbon/web-components";
 // Composables
 import { useEventBus } from "@vueuse/core";
 // Types
@@ -32,7 +35,7 @@ const selectedValue = ref<string>(props.initialValue);
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
+const revalidateBus = useEventBus<string[] | undefined>("revalidate-bus");
 
 //We watch for error changes to emit events
 watch(error, () => emit("error", error.value));
@@ -72,7 +75,7 @@ const updateSelectedValue = (event: any) =>
   (selectedValue.value = event.detail.value);
 revalidateBus.on((keys: string[] | undefined) => {
   if (keys === undefined || keys.includes(props.id)) {
-    validateInput()
+    validateInput();
   }
 });
 
@@ -80,68 +83,84 @@ const ariaInvalidString = computed(() => (error.value ? "true" : "false"));
 
 const isFocused = ref(false);
 
-const cdsRadioButtonGroupRef = ref<InstanceType<typeof CDSRadioButtonGroup> | null>(null);
+const cdsRadioButtonGroupRef = ref<InstanceType<
+  typeof CDSRadioButtonGroup
+> | null>(null);
 
-watch([cdsRadioButtonGroupRef, isFocused, ariaInvalidString], async ([cdsRadioButtonGroup]) => {
-  if (cdsRadioButtonGroup) {
-    // wait for the DOM updates to complete
-    await nextTick();
+watch(
+  [cdsRadioButtonGroupRef, isFocused, ariaInvalidString],
+  async ([cdsRadioButtonGroup]) => {
+    if (cdsRadioButtonGroup) {
+      // wait for the DOM updates to complete
+      await nextTick();
 
-    const helperTextId = "helper-text";
-    const helperText = cdsRadioButtonGroup.shadowRoot?.querySelector(".cds--form__helper-text");
-    if (helperText) {
-      helperText.id = helperTextId;
-    }
-
-    const invalidTextId = "invalid-text";
-    const invalidText = cdsRadioButtonGroup.shadowRoot?.querySelector(".cds--form-requirement");
-    if (invalidText) {
-      invalidText.id = invalidTextId;
-
-      // For some reason the role needs to be dynamically changed to "alert" to announce.
-      if (isFocused.value) {
-        invalidText.role = "generic";
-      } else {
-        invalidText.role = ariaInvalidString.value === "true" ? "alert" : "generic";
-      }
-    }
-
-    const fieldset = cdsRadioButtonGroup.shadowRoot?.querySelector("fieldset");
-    if (fieldset) {
-      fieldset.role = "radiogroup";
-      fieldset.setAttribute("aria-label", props.label);
-      fieldset.ariaInvalid = ariaInvalidString.value;
-
-      // Use the helper text as a field description
-      fieldset.setAttribute(
-        "aria-describedby",
-        ariaInvalidString.value === "true" ? invalidTextId : helperTextId,
+      const helperTextId = "helper-text";
+      const helperText = cdsRadioButtonGroup.shadowRoot?.querySelector(
+        ".cds--form__helper-text"
       );
+      if (helperText) {
+        helperText.id = helperTextId;
+      }
+
+      const invalidTextId = "invalid-text";
+      const invalidText = cdsRadioButtonGroup.shadowRoot?.querySelector(
+        ".cds--form-requirement"
+      );
+      if (invalidText) {
+        invalidText.id = invalidTextId;
+
+        // For some reason the role needs to be dynamically changed to "alert" to announce.
+        if (isFocused.value) {
+          invalidText.role = "generic";
+        } else {
+          invalidText.role =
+            ariaInvalidString.value === "true" ? "alert" : "generic";
+        }
+      }
+
+      const fieldset =
+        cdsRadioButtonGroup.shadowRoot?.querySelector("fieldset");
+      if (fieldset) {
+        fieldset.role = "radiogroup";
+        fieldset.setAttribute("aria-label", props.label);
+        fieldset.ariaInvalid = ariaInvalidString.value;
+
+        // Use the helper text as a field description
+        fieldset.setAttribute(
+          "aria-describedby",
+          ariaInvalidString.value === "true" ? invalidTextId : helperTextId
+        );
+      }
     }
   }
-});
+);
 
-const cdsRadioButtonArrayRef = ref<InstanceType<typeof CDSRadioButton>[] | null>(null);
+const cdsRadioButtonArrayRef = ref<
+  InstanceType<typeof CDSRadioButton>[] | null
+>(null);
 
-watch([cdsRadioButtonArrayRef, () => props.required], async (cdsRadioButtonArray) => {
-  if (cdsRadioButtonArray) {
-    // wait for the DOM updates to complete
-    await nextTick();
+watch(
+  [cdsRadioButtonArrayRef, () => props.required],
+  async (cdsRadioButtonArray) => {
+    if (cdsRadioButtonArray) {
+      // wait for the DOM updates to complete
+      await nextTick();
 
-    for (const radio of cdsRadioButtonArrayRef.value) {
-      const label = radio.shadowRoot?.querySelector("label");
-      if (label) {
-        // Fixes the association as it's wrong in the component.
-        label.htmlFor = "radio";
-      }
-      const input = radio.shadowRoot?.querySelector("input");
-      if (input) {
-        // Propagate attributes to the input
-        input.required = props.required;
+      for (const radio of cdsRadioButtonArrayRef.value) {
+        const label = radio.shadowRoot?.querySelector("label");
+        if (label) {
+          // Fixes the association as it's wrong in the component.
+          label.htmlFor = "radio";
+        }
+        const input = radio.shadowRoot?.querySelector("input");
+        if (input) {
+          // Propagate attributes to the input
+          input.required = props.required;
+        }
       }
     }
   }
-});
+);
 
 // For the radio-button component the Screen Reader has proved more responsive to alerts with aria-live set.
 const ariaLive = "polite";

--- a/frontend/src/components/forms/RadioInputComponent.vue
+++ b/frontend/src/components/forms/RadioInputComponent.vue
@@ -71,7 +71,7 @@ watch(selectedValue, () => {
 const updateSelectedValue = (event: any) =>
   (selectedValue.value = event.detail.value);
 revalidateBus.on((keys: string[] | undefined) => {
-  if(keys === undefined || keys.includes(props.id)) {
+  if (keys === undefined || keys.includes(props.id)) {
     validateInput()
   }
 });

--- a/frontend/src/components/forms/RadioInputComponent.vue
+++ b/frontend/src/components/forms/RadioInputComponent.vue
@@ -32,7 +32,7 @@ const selectedValue = ref<string>(props.initialValue);
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<void>("revalidate-bus");
+const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
 
 //We watch for error changes to emit events
 watch(error, () => emit("error", error.value));
@@ -70,7 +70,11 @@ watch(selectedValue, () => {
 
 const updateSelectedValue = (event: any) =>
   (selectedValue.value = event.detail.value);
-revalidateBus.on(() => validateInput());
+revalidateBus.on((keys: string[] | undefined) => {
+  if(keys === undefined || keys.includes(props.id)) {
+    validateInput()
+  }
+});
 
 const ariaInvalidString = computed(() => (error.value ? "true" : "false"));
 

--- a/frontend/src/components/forms/TextInputComponent.vue
+++ b/frontend/src/components/forms/TextInputComponent.vue
@@ -31,8 +31,8 @@ const props = withDefaults(
   }>(),
   {
     type: "text",
-    enabled: true
-  },
+    enabled: true,
+  }
 );
 
 //Events we emit during component lifecycle
@@ -45,7 +45,7 @@ const emit = defineEmits<{
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
+const revalidateBus = useEventBus<string[] | undefined>("revalidate-bus");
 
 const warning = ref(false);
 
@@ -54,7 +54,8 @@ const warning = ref(false);
  * @param errorObject - the error object or string
  */
 const setError = (errorObject: string | ValidationMessageType | undefined) => {
-  const errorMessage = typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
+  const errorMessage =
+    typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
   error.value = errorMessage || "";
 
   warning.value = false;
@@ -69,12 +70,12 @@ const setError = (errorObject: string | ValidationMessageType | undefined) => {
   rely on empty(false) to consider a value "valid". In turn we need to emit a new error event after
   an empty one to allow subscribers to know in case the field still has the same error.
   */
-  emit('error', error.value);
-}
+  emit("error", error.value);
+};
 
 watch(
   () => props.errorMessage,
-  () => setError(props.errorMessage),
+  () => setError(props.errorMessage)
 );
 
 //We set it as a separated ref due to props not being updatable
@@ -102,8 +103,8 @@ watch([selectedValue], () => {
 });
 
 //We call all the validations
-const validateInput = (newValue: string) => {  
-  if (props.validations) {    
+const validateInput = (newValue: string) => {
+  if (props.validations) {
     setError(
       props.validations
         .map((validation) => validation(newValue))
@@ -111,10 +112,7 @@ const validateInput = (newValue: string) => {
           if (errorMessage) return true;
           return false;
         })
-        .reduce(
-          (acc, errorMessage) => acc || errorMessage,
-          props.errorMessage,
-        )
+        .reduce((acc, errorMessage) => acc || errorMessage, props.errorMessage)
     );
   }
 };
@@ -135,7 +133,7 @@ const isUserEvent = ref(false);
 
 const selectValue = (event: any) => {
   selectedValue.value = event.target.value;
-  isUserEvent.value = true
+  isUserEvent.value = true;
 };
 
 const originalDescribedBy = ref<string>();
@@ -147,14 +145,22 @@ const ariaInvalidString = computed(() => (error.value ? "true" : "false"));
 const cdsTextInputRef = ref<InstanceType<typeof CDSTextInput> | null>(null);
 
 watch(
-  [cdsTextInputRef, () => props.numeric, () => props.type, isFocused, ariaInvalidString],
+  [
+    cdsTextInputRef,
+    () => props.numeric,
+    () => props.type,
+    isFocused,
+    ariaInvalidString,
+  ],
   async ([cdsTextInput]) => {
     if (cdsTextInput) {
       // wait for the DOM updates to complete
       await nextTick();
 
       const invalidTextId = "invalid-text";
-      const invalidText = cdsTextInput.shadowRoot?.querySelector("[name='invalid-text']");
+      const invalidText = cdsTextInput.shadowRoot?.querySelector(
+        "[name='invalid-text']"
+      );
       if (invalidText) {
         invalidText.id = invalidTextId;
 
@@ -162,7 +168,8 @@ watch(
         if (isFocused.value) {
           invalidText.role = "generic";
         } else {
-          invalidText.role = ariaInvalidString.value === "true" ? "alert" : "generic";
+          invalidText.role =
+            ariaInvalidString.value === "true" ? "alert" : "generic";
         }
       }
 
@@ -183,11 +190,13 @@ watch(
         // Use the helper text as a field description
         input.setAttribute(
           "aria-describedby",
-          ariaInvalidString.value === "true" ? invalidTextId : originalDescribedBy.value,
+          ariaInvalidString.value === "true"
+            ? invalidTextId
+            : originalDescribedBy.value
         );
       }
     }
-  },
+  }
 );
 </script>
 

--- a/frontend/src/components/forms/TextInputComponent.vue
+++ b/frontend/src/components/forms/TextInputComponent.vue
@@ -120,7 +120,7 @@ const validateInput = (newValue: string) => {
 };
 
 revalidateBus.on((keys: string[] | undefined) => {
-  if(keys === undefined || keys.includes(props.id)) {
+  if (keys === undefined || keys.includes(props.id)) {
     validateInput(selectedValue.value);
   }
 });

--- a/frontend/src/components/forms/TextInputComponent.vue
+++ b/frontend/src/components/forms/TextInputComponent.vue
@@ -45,7 +45,7 @@ const emit = defineEmits<{
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<void>("revalidate-bus");
+const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
 
 const warning = ref(false);
 
@@ -119,8 +119,10 @@ const validateInput = (newValue: string) => {
   }
 };
 
-revalidateBus.on(() => {
-  validateInput(selectedValue.value);
+revalidateBus.on((keys: string[] | undefined) => {
+  if(keys === undefined || keys.includes(props.id)) {
+    validateInput(selectedValue.value);
+  }
 });
 
 watch(

--- a/frontend/src/components/forms/TextareaInputComponent.vue
+++ b/frontend/src/components/forms/TextareaInputComponent.vue
@@ -109,7 +109,7 @@ const validateInput = (newValue: string) => {
 };
 
 revalidateBus.on((keys: string[] | undefined) => {
-  if(keys === undefined || keys.includes(props.id)) {
+  if (keys === undefined || keys.includes(props.id)) {
     validateInput(selectedValue.value);
   }
 });

--- a/frontend/src/components/forms/TextareaInputComponent.vue
+++ b/frontend/src/components/forms/TextareaInputComponent.vue
@@ -24,7 +24,7 @@ const props = withDefaults(
     enableCounter?: boolean;
     maxCount?: number;
   }>(),
-  {},
+  {}
 );
 
 //Events we emit during component lifecycle
@@ -37,7 +37,7 @@ const emit = defineEmits<{
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
+const revalidateBus = useEventBus<string[] | undefined>("revalidate-bus");
 
 const warning = ref(false);
 
@@ -46,7 +46,8 @@ const warning = ref(false);
  * @param errorObject - the error object or string
  */
 const setError = (errorObject: string | ValidationMessageType | undefined) => {
-  const errorMessage = typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
+  const errorMessage =
+    typeof errorObject === "object" ? errorObject.errorMsg : errorObject;
   error.value = errorMessage || "";
 
   warning.value = false;
@@ -61,12 +62,12 @@ const setError = (errorObject: string | ValidationMessageType | undefined) => {
   rely on empty(false) to consider a value "valid". In turn we need to emit a new error event after
   an empty one to allow subscribers to know in case the field still has the same error.
   */
-  emit('error', error.value);
-}
+  emit("error", error.value);
+};
 
 watch(
   () => props.errorMessage,
-  () => setError(props.errorMessage),
+  () => setError(props.errorMessage)
 );
 
 //We set it as a separated ref due to props not being updatable
@@ -103,7 +104,7 @@ const validateInput = (newValue: string) => {
           if (errorMessage) return true;
           return false;
         })
-        .shift() ?? props.errorMessage,
+        .shift() ?? props.errorMessage
     );
   }
 };
@@ -116,7 +117,7 @@ revalidateBus.on((keys: string[] | undefined) => {
 
 watch(
   () => props.modelValue,
-  () => (selectedValue.value = props.modelValue),
+  () => (selectedValue.value = props.modelValue)
 );
 
 // Tells whether the current change was done manually by the user.

--- a/frontend/src/components/forms/TextareaInputComponent.vue
+++ b/frontend/src/components/forms/TextareaInputComponent.vue
@@ -37,7 +37,7 @@ const emit = defineEmits<{
 //We initialize the error message handling for validation
 const error = ref<string | undefined>(props.errorMessage ?? "");
 
-const revalidateBus = useEventBus<void>("revalidate-bus");
+const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
 
 const warning = ref(false);
 
@@ -108,8 +108,10 @@ const validateInput = (newValue: string) => {
   }
 };
 
-revalidateBus.on(() => {
-  validateInput(selectedValue.value);
+revalidateBus.on((keys: string[] | undefined) => {
+  if(keys === undefined || keys.includes(props.id)) {
+    validateInput(selectedValue.value);
+  }
 });
 
 watch(

--- a/frontend/src/helpers/validators/StaffFormValidations.ts
+++ b/frontend/src/helpers/validators/StaffFormValidations.ts
@@ -18,6 +18,8 @@ import {
   optional,
   isAsciiLineBreak,
   isNotEmptyArray,
+  validate as globalValidate,
+  runValidation as globalRunValidation,
 } from "@/helpers/validators/GlobalValidators";
 
 // Allow externalFormFieldValidations to get populated
@@ -324,3 +326,15 @@ export const addValidation = (key: string, validation: (value: string) => string
   if (!fieldValidations[key]) fieldValidations[key] = [];
   fieldValidations[key].push(validation);
 };
+
+const defaultGetValidations = getValidations;
+
+export const validate = (
+  ...args: Parameters<typeof globalValidate>
+): ReturnType<typeof globalValidate> => {  
+  const getValidations = args[3] || defaultGetValidations;
+  args[3] = getValidations;
+  return globalValidate.apply(this, args);
+};
+
+export const runValidation = globalRunValidation;

--- a/frontend/src/helpers/validators/StaffFormValidations.ts
+++ b/frontend/src/helpers/validators/StaffFormValidations.ts
@@ -12,8 +12,6 @@ import {
   isIdCharacters,
   isExactSize,
   formFieldValidations as externalFormFieldValidations,
-  validate as globalValidate,
-  runValidation as globalRunValidation,
   isAscii,
   isEmail,
   isPhoneNumber,
@@ -64,8 +62,8 @@ fieldValidations["businessInformation.firstName"] = [
 ];
 
 fieldValidations["businessInformation.middleName"] = [
-  isMaxSizeMsg("middle name", 30),
-  hasOnlyNamingCharacters("middle name"),
+  optional(isMaxSizeMsg("middle name", 30)),
+  optional(hasOnlyNamingCharacters("middle name")),
 ];
 
 // use the same validations as lastName in contacts
@@ -326,15 +324,3 @@ export const addValidation = (key: string, validation: (value: string) => string
   if (!fieldValidations[key]) fieldValidations[key] = [];
   fieldValidations[key].push(validation);
 };
-
-const defaultGetValidations = getValidations;
-
-export const validate = (
-  ...args: Parameters<typeof globalValidate>
-): ReturnType<typeof globalValidate> => {  
-  const getValidations = args[3] || defaultGetValidations;
-  args[3] = getValidations;
-  return globalValidate.apply(this, args);
-};
-
-export const runValidation = globalRunValidation;

--- a/frontend/src/helpers/validators/SubmissionReviewValidations.ts
+++ b/frontend/src/helpers/validators/SubmissionReviewValidations.ts
@@ -1,5 +1,10 @@
 /* eslint-disable dot-notation */
-import { isMaxSize, isOnlyNumbers, isNotEmpty, isNotEmptyArray } from "@/helpers/validators/GlobalValidators";
+import {
+  isMaxSize,
+  isOnlyNumbers,
+  isNotEmpty,
+  isNotEmptyArray,
+} from "@/helpers/validators/GlobalValidators";
 
 const reviewFieldValidations: Record<string, ((value: any) => string)[]> = {};
 
@@ -10,7 +15,9 @@ export const getValidations = (key: string): ((value: any) => string)[] =>
 const isMaxSizeMsg = (fieldName: string, maxSize: number) =>
   isMaxSize(`The ${fieldName} has a ${maxSize} character limit`)(maxSize);
 
-reviewFieldValidations["reasons"] = [isNotEmptyArray("You must select at least one reason")];
+reviewFieldValidations["reasons"] = [
+  isNotEmptyArray("You must select at least one reason"),
+];
 
 reviewFieldValidations["message"] = [
   isNotEmpty("Matching client number cannot be empty"),

--- a/frontend/src/helpers/validators/SubmissionValidators.ts
+++ b/frontend/src/helpers/validators/SubmissionValidators.ts
@@ -31,7 +31,7 @@ const errorBus = useEventBus<ValidationMessageType[]>(
 /**
  * Event bus for revalidating the submission.
  */
-const revalidateBus = useEventBus<void>("revalidate-bus");
+const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
 
 /**
  * Event bus for error notifications bar.

--- a/frontend/src/pages/FormBCeIDPage.vue
+++ b/frontend/src/pages/FormBCeIDPage.vue
@@ -52,7 +52,7 @@ const notificationBus = useEventBus<ValidationMessageType | undefined>(
 );
 const exitBus =
   useEventBus<Record<string, boolean | null>>("exit-notification");
-const revalidateBus = useEventBus<void>("revalidate-bus");
+const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
 const progressIndicatorBus = useEventBus<ProgressNotification>(
   "progress-indicator-bus"
 );

--- a/frontend/src/pages/FormBCeIDPage.vue
+++ b/frontend/src/pages/FormBCeIDPage.vue
@@ -52,7 +52,7 @@ const notificationBus = useEventBus<ValidationMessageType | undefined>(
 );
 const exitBus =
   useEventBus<Record<string, boolean | null>>("exit-notification");
-const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
+const revalidateBus = useEventBus<string[] | undefined>("revalidate-bus");
 const progressIndicatorBus = useEventBus<ProgressNotification>(
   "progress-indicator-bus"
 );
@@ -135,7 +135,7 @@ watch([error], () => {
         fieldId: "server.validation.error",
         fieldName: convertFieldNameToSentence(errorItem.fieldId),
         errorMsg: errorItem.errorMsg,
-      }),
+      })
     );
   } else {
     handleErrorDefault();
@@ -281,7 +281,6 @@ const goToStep = (index: number, skipCheck: boolean = false) => {
   revalidateBus.emit();
 };
 
-
 /*
 We do not auto focus the first step in the first rendering to prevent skipping form instructions.
 The differenct might only be noticeable when using a screen reader.
@@ -330,7 +329,9 @@ const processAndLogOut = () => {
       {
         registrationNumber: formData.businessInformation.registrationNumber,
         name: formData.businessInformation.businessName,
-        userName: `${ForestClientUserSession.user?.firstName} ${ForestClientUserSession.user?.lastName}` ?? "",
+        userName:
+          `${ForestClientUserSession.user?.firstName} ${ForestClientUserSession.user?.lastName}` ??
+          "",
         userId: ForestClientUserSession.user.userId ?? "",
         email: ForestClientUserSession.user.email ?? "",
       },
@@ -355,7 +356,9 @@ const submit = () => {
 exitBus.on((event: Record<string, boolean | null>) => {
   endAndLogOut.value = event.goodStanding ? event.goodStanding : false;
   mailAndLogOut.value = event.duplicated ? event.duplicated : false;
-  endAndLogOut.value = event.nonPersonSP ? event.nonPersonSP : endAndLogOut.value;
+  endAndLogOut.value = event.nonPersonSP
+    ? event.nonPersonSP
+    : endAndLogOut.value;
   endAndLogOut.value = event.unsupportedClientType || endAndLogOut.value;
 });
 
@@ -397,10 +400,12 @@ const formattedDistrictsList = computed(() =>
   districtsList.value.map((district) => ({
     ...district,
     name: `${district.code} - ${district.name}`,
-  })),
+  }))
 );
 
-const cdsProgressStepArray = ref<InstanceType<typeof CDSProgressStep>[] | null>(null);
+const cdsProgressStepArray = ref<InstanceType<typeof CDSProgressStep>[] | null>(
+  null
+);
 
 watch(cdsProgressStepArray, async (array) => {
   if (array) {

--- a/frontend/src/pages/FormStaffPage.vue
+++ b/frontend/src/pages/FormStaffPage.vue
@@ -352,6 +352,7 @@ const goToStep = (index: number, skipCheck: boolean = false) => {
 const submitBtnDisabled = ref(false);
 
 const submit = () => {
+  revalidateBus.emit();
   errorBus.emit([]);
   notificationBus.emit(undefined);
 
@@ -410,11 +411,13 @@ const submit = () => {
     setScrollPoint("top-notification");
   });
 
-  if (checkStepValidity(currentTab.value)) {
+  setTimeout(() => {
+    if (checkStepValidity(currentTab.value)) {
     submitBtnDisabled.value = true;
     overlayBus.emit({ isVisible: true, message: "", showLoading: true });
     fetchSubmission();
   }
+  }, 1);
 };
 </script>
 

--- a/frontend/src/pages/FormStaffPage.vue
+++ b/frontend/src/pages/FormStaffPage.vue
@@ -32,9 +32,7 @@ import {
   convertFieldNameToSentence,
 } from "@/services/ForestClientService";
 // Imported global validations
-import {
-  getValidations,
-} from "@/helpers/validators/StaffFormValidations";
+import { getValidations } from "@/helpers/validators/StaffFormValidations";
 import {
   submissionValidation,
   resetSubmissionValidators,
@@ -56,7 +54,9 @@ import ForestClientUserSession from "@/helpers/ForestClientUserSession";
 import ArrowRight16 from "@carbon/icons-vue/es/arrow--right/16";
 import Check16 from "@carbon/icons-vue/es/checkmark/16";
 
-const isAdminInd = ["CLIENT_ADMIN"].some(authority => ForestClientUserSession.authorities.includes(authority));
+const isAdminInd = ["CLIENT_ADMIN"].some((authority) =>
+  ForestClientUserSession.authorities.includes(authority)
+);
 
 const clientTypesList: CodeNameType[] = [
   {
@@ -96,7 +96,7 @@ const errorBus = useEventBus<ValidationMessageType[]>(
 );
 const overlayBus = useEventBus<boolean>("overlay-event");
 const fuzzyBus = useEventBus<FuzzyMatcherEvent>("fuzzy-error-notification");
-const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
+const revalidateBus = useEventBus<string[] | undefined>("revalidate-bus");
 
 // Route related
 const router = useRouter();
@@ -145,7 +145,8 @@ const currentTab = ref(0);
 const isLast = computed(() => currentTab.value === progressData.length - 1);
 const isFirst = computed(() => currentTab.value === 0);
 
-const checkStepValidity = (stepNumber: number): boolean => progressData[stepNumber].valid;
+const checkStepValidity = (stepNumber: number): boolean =>
+  progressData[stepNumber].valid;
 
 const validateStep = (valid: boolean) => {
   progressData[currentTab.value].valid = valid;
@@ -260,19 +261,19 @@ const onNext = () => {
   revalidateBus.emit();
 
   //This is now inside a setTimeout to allow the revalidateBus to finish
-  setTimeout(() => {    
+  setTimeout(() => {
     notificationBus.emit(undefined);
-  if (currentTab.value + 1 < progressData.length) {      
-    if (checkStepValidity(currentTab.value)) {
-      if (reviewStatement.value) {
-        moveToNextStep();
+    if (currentTab.value + 1 < progressData.length) {
+      if (checkStepValidity(currentTab.value)) {
+        if (reviewStatement.value) {
+          moveToNextStep();
+        } else {
+          lookForMatches(moveToNextStep);
+        }
       } else {
-        lookForMatches(moveToNextStep);
+        setScrollPoint("top-notification");
       }
-    } else {
-      setScrollPoint("top-notification");
     }
-  }
   }, 1);
 };
 
@@ -312,7 +313,10 @@ const updateClientType = (value: CodeNameType | undefined) => {
     const updateFormData = (clientTypeEnum?: ClientTypeEnum) => {
       Object.assign(formData.businessInformation, commonBusinessInfo);
       if (clientTypeEnum) {
-        formData.businessInformation.clientType = getEnumKeyByEnumValue(ClientTypeEnum, clientTypeEnum);
+        formData.businessInformation.clientType = getEnumKeyByEnumValue(
+          ClientTypeEnum,
+          clientTypeEnum
+        );
       }
       formData.location.contacts[0] = applicantContact;
     };
@@ -414,10 +418,10 @@ const submit = () => {
 
   setTimeout(() => {
     if (checkStepValidity(currentTab.value)) {
-    submitBtnDisabled.value = true;
-    overlayBus.emit({ isVisible: true, message: "", showLoading: true });
-    fetchSubmission();
-  }
+      submitBtnDisabled.value = true;
+      overlayBus.emit({ isVisible: true, message: "", showLoading: true });
+      fetchSubmission();
+    }
   }, 1);
 };
 </script>

--- a/frontend/src/pages/FormStaffPage.vue
+++ b/frontend/src/pages/FormStaffPage.vue
@@ -402,10 +402,6 @@ const goToStep = (index: number, skipCheck: boolean = false) => {
   revalidateBus.emit(progressData[currentTab.value].fields);
 };
 
-revalidateBus.on((fields: string[]|undefined) => {
-  console.log("Revalidating fields", fields);
-});
-
 const submitBtnDisabled = ref(false);
 
 const submit = () => {

--- a/frontend/src/pages/FormStaffPage.vue
+++ b/frontend/src/pages/FormStaffPage.vue
@@ -170,7 +170,7 @@ watch(formData, () => {
   if (matchError.value) {
     fuzzyBus.emit(undefined);
     resetSubmissionValidators();
-    revalidateBus.emit(progressData[currentTab.value].fields);
+    revalidateBus.emit();
     matchError.value = false;
   }
 });
@@ -244,6 +244,14 @@ const moveToNextStep = () => {
   resetSubmissionValidators();
 
   fuzzyBus.emit(undefined);
+
+  //This fixes the index
+  formData.location.addresses.forEach(
+    (address: Address, index: number) => (address.index = index)
+  );
+  formData.location.contacts.forEach(
+    (contact: Contact, index: number) => (contact.index = index)
+  );
 };
 
 const onNext = () => {
@@ -257,13 +265,6 @@ const onNext = () => {
   if (currentTab.value + 1 < progressData.length) {      
     if (checkStepValidity(currentTab.value)) {
       if (reviewStatement.value) {
-        //This fixes the index
-        formData.location.addresses.forEach(
-          (address: Address, index: number) => (address.index = index)
-        );
-        formData.location.contacts.forEach(
-          (contact: Contact, index: number) => (contact.index = index)
-        );
         moveToNextStep();
       } else {
         lookForMatches(moveToNextStep);
@@ -282,7 +283,7 @@ const onBack = () => {
     progressData[currentTab.value + 1].kind = "incomplete";
     progressData[currentTab.value].kind = "current";
     setScrollPoint("step-title");
-    setTimeout(() => revalidateBus.emit(progressData[currentTab.value].fields), 1000);
+    setTimeout(revalidateBus.emit, 1000);
   }
 };
 
@@ -346,7 +347,7 @@ const goToStep = (index: number, skipCheck: boolean = false) => {
   if (skipCheck || (index <= currentTab.value && checkStepValidity(index)))
     currentTab.value = index;
   else notificationBus.emit({ fieldId: "missing.info", errorMsg: "" });
-  revalidateBus.emit(progressData[currentTab.value].fields);
+  revalidateBus.emit();
 };
 
 const submitBtnDisabled = ref(false);

--- a/frontend/src/pages/FormStaffPage.vue
+++ b/frontend/src/pages/FormStaffPage.vue
@@ -114,11 +114,6 @@ const progressData = reactive([
     disabled: false,
     valid: false,
     step: 0,
-    fields: [
-      "businessInformation.businessType",
-      "businessInformation.businessName",
-      "businessInformation.clientType",
-    ]
   },
   {
     title: "Locations",
@@ -127,23 +122,6 @@ const progressData = reactive([
     disabled: true,
     valid: false,
     step: 1,
-    fields: [
-      "location.addresses.*.locationName",
-      "location.addresses.*.complementaryAddressOne",
-      "location.addresses.*.complementaryAddressTwo",
-      "location.addresses.*.country.text",
-      "location.addresses.*.province.text",
-      "location.addresses.*.city",
-      "location.addresses.*.streetAddress",
-      'location.addresses.*.postalCode($.location.addresses.*.country.value === "CA")',
-      'location.addresses.*.postalCode($.location.addresses.*.country.value === "US")',
-      'location.addresses.*.postalCode($.location.addresses.*.country.value !== "CA" && $.location.addresses.*.country.value !== "US")',
-      "location.addresses.*.emailAddress",
-      "location.addresses.*.businessPhoneNumber",
-      "location.addresses.*.secondaryPhoneNumber",
-      "location.addresses.*.faxNumber",
-      "location.addresses.*.notes",
-    ]
   },
   {
     title: "Contacts",
@@ -152,16 +130,6 @@ const progressData = reactive([
     disabled: true,
     valid: false,
     step: 2,
-    fields: [
-      "location.contacts.*.locationNames.*.text",
-      "location.contacts.*.contactType.text",
-      "location.contacts.*.firstName",
-      "location.contacts.*.lastName",
-      "location.contacts.*.email",
-      "location.contacts.*.phoneNumber",
-      "location.contacts.*.secondaryPhoneNumber",
-      "location.contacts.*.faxNumber",
-    ]
   },
   {
     title: "Review",
@@ -170,32 +138,6 @@ const progressData = reactive([
     disabled: true,
     valid: false,
     step: 3,
-    fields: [
-      "businessInformation.businessType",
-      "businessInformation.businessName",
-      "businessInformation.clientType",
-      "businessInformation.notes",
-      "location.addresses.*.locationName",
-      "location.addresses.*.complementaryAddressOne",
-      "location.addresses.*.complementaryAddressTwo",
-      "location.addresses.*.country.text",
-      "location.addresses.*.province.text",
-      "location.addresses.*.city",
-      "location.addresses.*.streetAddress",
-      "location.addresses.*.emailAddress",
-      "location.addresses.*.businessPhoneNumber",
-      "location.addresses.*.secondaryPhoneNumber",
-      "location.addresses.*.faxNumber",
-      "location.addresses.*.notes",
-      "location.contacts.*.locationNames.*.text",
-      "location.contacts.*.contactType.text",
-      "location.contacts.*.firstName",
-      "location.contacts.*.lastName",
-      "location.contacts.*.email",
-      "location.contacts.*.phoneNumber",
-      "location.contacts.*.secondaryPhoneNumber",
-      "location.contacts.*.faxNumber",
-    ]
   },
 ]);
 const currentTab = ref(0);
@@ -305,19 +247,23 @@ const moveToNextStep = () => {
 };
 
 const onNext = () => {
-  revalidateBus.emit(progressData[currentTab.value].fields);
-  //This fixes the index
-  formData.location.addresses.forEach(
-    (address: Address, index: number) => (address.index = index)
-  );
-  formData.location.contacts.forEach(
-    (contact: Contact, index: number) => (contact.index = index)
-  );
+  //This will trigger and force the validation of the current step
+  //We don't pass any field id here to force the validation of all fields
+  revalidateBus.emit();
 
-  notificationBus.emit(undefined);
-  if (currentTab.value + 1 < progressData.length) {
+  //This is now inside a setTimeout to allow the revalidateBus to finish
+  setTimeout(() => {    
+    notificationBus.emit(undefined);
+  if (currentTab.value + 1 < progressData.length) {      
     if (checkStepValidity(currentTab.value)) {
       if (reviewStatement.value) {
+        //This fixes the index
+        formData.location.addresses.forEach(
+          (address: Address, index: number) => (address.index = index)
+        );
+        formData.location.contacts.forEach(
+          (contact: Contact, index: number) => (contact.index = index)
+        );
         moveToNextStep();
       } else {
         lookForMatches(moveToNextStep);
@@ -326,6 +272,7 @@ const onNext = () => {
       setScrollPoint("top-notification");
     }
   }
+  }, 1);
 };
 
 const onBack = () => {

--- a/frontend/src/pages/bceidform/ReviewWizardStep.vue
+++ b/frontend/src/pages/bceidform/ReviewWizardStep.vue
@@ -9,10 +9,10 @@ import { useFocus } from "@/composables/useFocus";
 import type { FormDataDto } from "@/dto/ApplyClientNumberDto";
 // @ts-ignore
 import Edit16 from "@carbon/icons-vue/es/edit/16";
-import Enterprise20 from "@carbon/icons-vue/es/enterprise/20"
-import LocationStar20 from "@carbon/icons-vue/es/location--star/20"
-import Location20 from "@carbon/icons-vue/es/location/20"
-import User20 from "@carbon/icons-vue/es/user/20"
+import Enterprise20 from "@carbon/icons-vue/es/enterprise/20";
+import LocationStar20 from "@carbon/icons-vue/es/location--star/20";
+import Location20 from "@carbon/icons-vue/es/location/20";
+import User20 from "@carbon/icons-vue/es/user/20";
 import { useFetchTo } from "@/composables/useFetch";
 import { CodeNameType } from "@/dto/CommonTypesDto";
 import { codeConversionFn } from "@/services/ForestClientService";
@@ -30,7 +30,7 @@ const emit = defineEmits<{
   (e: "valid", value: boolean): void;
 }>();
 
-const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
+const revalidateBus = useEventBus<string[] | undefined>("revalidate-bus");
 
 //Set the prop as a ref, and then emit when it changes
 const formData = ref<FormDataDto>(props.data);
@@ -38,8 +38,8 @@ watch([formData], () => emit("update:data", formData.value));
 
 const districtObject = computed(() =>
   props.districtsList.find(
-    (district) => district.code === formData.value.businessInformation.district,
-  ),
+    (district) => district.code === formData.value.businessInformation.district
+  )
 );
 
 const receviedClientType = ref({} as CodeNameType);

--- a/frontend/src/pages/bceidform/ReviewWizardStep.vue
+++ b/frontend/src/pages/bceidform/ReviewWizardStep.vue
@@ -30,7 +30,7 @@ const emit = defineEmits<{
   (e: "valid", value: boolean): void;
 }>();
 
-const revalidateBus = useEventBus<void>("revalidate-bus");
+const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
 
 //Set the prop as a ref, and then emit when it changes
 const formData = ref<FormDataDto>(props.data);

--- a/frontend/src/pages/staffform/IndividualClientInformationWizardStep.vue
+++ b/frontend/src/pages/staffform/IndividualClientInformationWizardStep.vue
@@ -16,7 +16,6 @@ import type {
 // Importing validators
 import {
   getValidations,
-  validate,
   clientIdentificationMaskParams,
 } from "@/helpers/validators/StaffFormValidations";
 import { submissionValidation } from "@/helpers/validators/SubmissionValidators";
@@ -132,9 +131,7 @@ watch(shouldDisplayProvince, (value) => {
 // -- Validation of the component --
 const validation = reactive<Record<string, boolean>>({
   firstName: false,
-  middleName:
-    !formData.value.businessInformation.middleName || // since middleName is not required
-    validate(["businessInformation.middleName"], formData.value),
+  middleName: true,
   lastName: false,
   birthdate: false,
   identificationType: false,

--- a/frontend/src/pages/staffform/ReviewWizardStep.vue
+++ b/frontend/src/pages/staffform/ReviewWizardStep.vue
@@ -78,8 +78,6 @@ const checkValid = () =>
 watch([validation], () => {
   emit("valid", checkValid());
 });
-
-emit("valid", false);
 </script>
 
 <template>

--- a/frontend/src/pages/staffform/ReviewWizardStep.vue
+++ b/frontend/src/pages/staffform/ReviewWizardStep.vue
@@ -3,7 +3,6 @@ import { watch, ref, onMounted, computed, reactive } from "vue";
 // Carbon
 import "@carbon/web-components/es/components/button/index";
 import "@carbon/web-components/es/components/tooltip/index";
-
 // Composables
 import { useEventBus } from "@vueuse/core";
 import { useFocus } from "@/composables/useFocus";
@@ -12,10 +11,10 @@ import type { FormDataDto } from "@/dto/ApplyClientNumberDto";
 import type { CodeNameType } from "@/dto/CommonTypesDto";
 // @ts-ignore
 import Edit16 from "@carbon/icons-vue/es/edit/16";
-import Enterprise20 from "@carbon/icons-vue/es/enterprise/20"
-import LocationStar20 from "@carbon/icons-vue/es/location--star/20"
-import Location20 from "@carbon/icons-vue/es/location/20"
-import User20 from "@carbon/icons-vue/es/user/20"
+import Enterprise20 from "@carbon/icons-vue/es/enterprise/20";
+import LocationStar20 from "@carbon/icons-vue/es/location--star/20";
+import Location20 from "@carbon/icons-vue/es/location/20";
+import User20 from "@carbon/icons-vue/es/user/20";
 import Information16 from "@carbon/icons-vue/es/information/16";
 
 import { useFetchTo } from "@/composables/useFetch";
@@ -35,7 +34,7 @@ const emit = defineEmits<{
   (e: "valid", value: boolean): void;
 }>();
 
-const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
+const revalidateBus = useEventBus<string[] | undefined>("revalidate-bus");
 
 //Set the prop as a ref, and then emit when it changes
 const formData = ref<FormDataDto>(props.data);
@@ -66,17 +65,18 @@ const nameError = ref<string | undefined>("");
 
 // Validations
 const validation = reactive<Record<string, boolean>>({
-  notes: true
+  notes: true,
 });
 
 const checkValid = () =>
   Object.values(validation).reduce(
-    (accumulator: boolean, currentValue: boolean) => accumulator && currentValue,
-    true,
+    (accumulator: boolean, currentValue: boolean) =>
+      accumulator && currentValue,
+    true
   );
 
 watch([validation], () => {
-  emit("valid", checkValid())
+  emit("valid", checkValid());
 });
 
 emit("valid", false);

--- a/frontend/src/pages/staffform/ReviewWizardStep.vue
+++ b/frontend/src/pages/staffform/ReviewWizardStep.vue
@@ -35,7 +35,7 @@ const emit = defineEmits<{
   (e: "valid", value: boolean): void;
 }>();
 
-const revalidateBus = useEventBus<void>("revalidate-bus");
+const revalidateBus = useEventBus<string[]|undefined>("revalidate-bus");
 
 //Set the prop as a ref, and then emit when it changes
 const formData = ref<FormDataDto>(props.data);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Changing the way the next call to validate works. Now, the validation will happen inside each component, by triggering the revalidationBus. With the current change, it will emit an event that can be either undefined or a list of keys.

The keys are a list of IDs of fields that need to be triggered to call the revalidate. This will prevent the next step from triggering the validation and showing with error even before showing up.

This will also take care of dynamic or changing validators. We will have to use when required the same strategy used for postal codes for example.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] Updated existing tests

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-35-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)