### PR TITLE
fix(fe): remove unrelated error-message from inputs

### DIFF
--- a/frontend/src/components/grouping/StaffContactGroupComponent.vue
+++ b/frontend/src/components/grouping/StaffContactGroupComponent.vue
@@ -264,7 +264,6 @@ const updateContactType = (value: CodeNameType | undefined) => {
       ]"
       required
       required-label
-      :error-message="error"
       @update:selected-value="
         selectedValue.locationNames = nameTypesToCodeDescr($event)
       "

--- a/frontend/src/components/grouping/StaffLocationGroupComponent.vue
+++ b/frontend/src/components/grouping/StaffLocationGroupComponent.vue
@@ -514,7 +514,6 @@ const getLocationDescription = (address: Address, index: number): string =>
         ...getValidations('location.addresses.*.notes'),
         submissionValidation(`location.addresses[${id}].notes`),
       ]"
-      :error-message="nameError"
       @empty="validation.notes = true"
       @error="validation.notes = !$event"
     >


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

When there is a unique validation in the front-end, unrelated inputs were displayed as invalid.
- On the Locations step (unique location name), the Notes input was also displayed as invalid;
- On the Contacts step (unique contact name - first name and last name), the Location name input was also displayed as invalid.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-19-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)