### PR TITLE
ci!: deprecate deployment configs, remove image streams, add ghcr tags

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -27,7 +27,7 @@ jobs:
 
   test-init:
     name: TEST Init
-    needs: [images-test]
+    needs: [vars]
     env:
       ZONE: test
       URL: forestclient-tst.nrs.gov.bc.ca
@@ -46,7 +46,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
             -p ORACLEDB_USER_W=${{ secrets.ORACLEDB_USERNAME_W }}
@@ -90,7 +90,7 @@ jobs:
 
   test-deploy:
     name: TEST Deployment
-    needs: [test-init]
+    needs: [vars, test-init]
     env:
       URL: forestclient-tst.nrs.gov.bc.ca
       ZONE: test
@@ -110,7 +110,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Backup database before update
         continue-on-error: true
@@ -131,7 +131,7 @@ jobs:
           overwrite: false
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Legacy
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -145,7 +145,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Processor
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -159,6 +159,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p TAG=${{ needs.vars.outputs.pr }}
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
 
       - name: Deploy Backend ConfigMap
@@ -172,7 +173,7 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Backend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -186,7 +187,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
@@ -204,7 +205,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Frontend ConfigMap
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -217,7 +218,7 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Frontend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -230,7 +231,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}
             -p URL=${{ env.URL }}
@@ -248,7 +249,7 @@ jobs:
 
   prod-init:
     name: PROD Init
-    needs: [images-prod]
+    needs: [vars, test-deploy]
     env:
       URL: forestclient.nrs.gov.bc.ca
       ZONE: prod
@@ -267,7 +268,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
             -p ORACLEDB_USER_W=${{ secrets.ORACLEDB_USERNAME_W }}
@@ -288,7 +289,7 @@ jobs:
 
   prod-deploy:
     name: PROD Deployment
-    needs: [prod-init]
+    needs: [vars, prod-init]
     env:
       PREV: test
       ZONE: prod
@@ -309,7 +310,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ needs.vars.outputs.pr }}
             
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
@@ -336,7 +337,7 @@ jobs:
           overwrite: false
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Legacy
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -350,7 +351,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
             
       - name: Deploy Processor
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -364,7 +365,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
 
       - name: Deploy Backend ConfigMap
@@ -378,7 +379,7 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Backend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -392,7 +393,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
@@ -410,7 +411,7 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Frontend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -423,7 +424,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}
             -p URL=${{ env.URL }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -45,7 +45,7 @@ jobs:
           oc_version: "4.13"
           overwrite: true
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
@@ -109,7 +109,7 @@ jobs:
           oc_version: "4.13"
           overwrite: true
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Backup database before update
@@ -130,7 +130,7 @@ jobs:
           oc_version: "4.13"
           overwrite: false
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Legacy
@@ -144,7 +144,7 @@ jobs:
           overwrite: true
           verification_path: health
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Processor
@@ -158,7 +158,7 @@ jobs:
           overwrite: true
           verification_path: health
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
 
@@ -186,7 +186,7 @@ jobs:
           overwrite: true
           verification_path: health
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
@@ -204,7 +204,7 @@ jobs:
           oc_version: "4.13"
           overwrite: true
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Frontend ConfigMap
@@ -230,7 +230,7 @@ jobs:
           oc_version: "4.13"
           overwrite: true
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}
@@ -267,7 +267,7 @@ jobs:
           oc_version: "4.13"
           overwrite: true
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
@@ -309,7 +309,7 @@ jobs:
           oc_version: "4.13"
           overwrite: true
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
             
       - name: Install CLI tools from OpenShift Mirror
@@ -336,7 +336,7 @@ jobs:
           oc_version: "4.13"
           overwrite: false
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Legacy
@@ -350,7 +350,7 @@ jobs:
           overwrite: true
           verification_path: health
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
             
       - name: Deploy Processor
@@ -364,7 +364,7 @@ jobs:
           overwrite: true
           verification_path: health
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
 
@@ -392,7 +392,7 @@ jobs:
           overwrite: true
           verification_path: health
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
@@ -423,7 +423,7 @@ jobs:
           oc_version: "4.13"
           overwrite: true
           parameters:
-            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -46,7 +46,6 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ needs.vars.outputs.pr }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
             -p ORACLEDB_USER_W=${{ secrets.ORACLEDB_USERNAME_W }}
@@ -110,7 +109,6 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Backup database before update
         continue-on-error: true
@@ -204,7 +202,6 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Frontend ConfigMap
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -266,7 +263,6 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ needs.vars.outputs.pr }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
             -p ORACLEDB_USER_W=${{ secrets.ORACLEDB_USERNAME_W }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           registry: ghcr.io
           repository: ${{ github.repository }}/${{ matrix.component }}
-          target: ${{ needs.vars.outputs.pr}}
+          target: ${{ needs.vars.outputs.pr }}
           tags: test
 
   test-init:
@@ -61,7 +61,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
             -p ORACLEDB_USER_W=${{ secrets.ORACLEDB_USERNAME_W }}
@@ -146,7 +146,7 @@ jobs:
           overwrite: false
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
             -p PROMOTE=${{ github.repository }}/database:${{ env.ZONE }}
 
       - name: Deploy Legacy
@@ -161,7 +161,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
             -p PROMOTE=${{ github.repository }}/legacy:${{ env.ZONE }}
             -p ENVIRONMENT=${{ secrets.OC_NAMESPACE }}
 
@@ -191,7 +191,7 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
 
       - name: Deploy Backend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -205,7 +205,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
             -p PROMOTE=${{ github.repository }}/backend:${{ env.ZONE }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
@@ -224,7 +224,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
 
       - name: Deploy Frontend ConfigMap
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -237,7 +237,7 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
 
       - name: Deploy Frontend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -250,7 +250,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
             -p PROMOTE=${{ github.repository }}/frontend:${{ env.ZONE }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}
@@ -303,7 +303,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
             -p ORACLEDB_USER_W=${{ secrets.ORACLEDB_USERNAME_W }}
@@ -386,7 +386,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
             -p PROMOTE=${{ github.repository }}/legacy:${{ env.PREV }}    
             
       - name: Deploy Processor
@@ -401,7 +401,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
             -p PROMOTE=${{ github.repository }}/processor:${{ env.PREV }}
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
 
@@ -416,7 +416,7 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
 
       - name: Deploy Backend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -430,7 +430,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
             -p PROMOTE=${{ github.repository }}/backend:${{ env.PREV }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
@@ -449,7 +449,7 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
 
       - name: Deploy Frontend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -462,7 +462,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ github.event.number }}
+            -p TAG=${{ env.ZONE }}
             -p PROMOTE=${{ github.repository }}/frontend:${{ env.PREV }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -109,6 +109,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }}
+            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Backup database before update
         continue-on-error: true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -61,6 +61,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p TAG=${{ github.event.number }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
             -p ORACLEDB_USER_W=${{ secrets.ORACLEDB_USERNAME_W }}
@@ -124,7 +125,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ github.event.number }}
 
       - name: Backup database before update
         continue-on-error: true
@@ -145,7 +146,8 @@ jobs:
           overwrite: false
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.ZONE }}
+            -p TAG=${{ github.event.number }}
+            -p PROMOTE=${{ github.repository }}/database:${{ env.ZONE }}
 
       - name: Deploy Legacy
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -159,6 +161,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p TAG=${{ github.event.number }}
             -p PROMOTE=${{ github.repository }}/legacy:${{ env.ZONE }}
             -p ENVIRONMENT=${{ secrets.OC_NAMESPACE }}
 
@@ -187,7 +190,8 @@ jobs:
           oc_version: "4.13"
           overwrite: true          
           parameters:
-            -p ZONE=${{ env.ZONE }}       
+            -p ZONE=${{ env.ZONE }}
+            -p TAG=${{ github.event.number }}
 
       - name: Deploy Backend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -201,6 +205,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p TAG=${{ github.event.number }}
             -p PROMOTE=${{ github.repository }}/backend:${{ env.ZONE }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
@@ -217,7 +222,9 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           oc_version: "4.13"
           overwrite: true
-          parameters: -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+          parameters:
+            -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p TAG=${{ github.event.number }}
 
       - name: Deploy Frontend ConfigMap
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -229,7 +236,8 @@ jobs:
           oc_version: "4.13"
           overwrite: true          
           parameters:
-            -p ZONE=${{ env.ZONE }} 
+            -p ZONE=${{ env.ZONE }}
+            -p TAG=${{ github.event.number }}
 
       - name: Deploy Frontend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -242,6 +250,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p TAG=${{ github.event.number }}
             -p PROMOTE=${{ github.repository }}/frontend:${{ env.ZONE }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}
@@ -294,6 +303,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p TAG=${{ github.event.number }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
             -p ORACLEDB_USER_W=${{ secrets.ORACLEDB_USERNAME_W }}
@@ -335,7 +345,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.PREV }}
+            -p TAG=${{ github.event.number }}
             
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
@@ -362,7 +372,7 @@ jobs:
           overwrite: false
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p TAG=${{ env.PREV }}
+            -p TAG=${{ github.event.number }}
 
       - name: Deploy Legacy
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -376,8 +386,8 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p PROMOTE=${{ github.repository }}/legacy:${{ env.PREV }}
-            -p ENVIRONMENT=${{ secrets.OC_NAMESPACE }}
+            -p TAG=${{ github.event.number }}
+            -p PROMOTE=${{ github.repository }}/legacy:${{ env.PREV }}    
             
       - name: Deploy Processor
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -391,6 +401,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p TAG=${{ github.event.number }}
             -p PROMOTE=${{ github.repository }}/processor:${{ env.PREV }}
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
 
@@ -404,7 +415,8 @@ jobs:
           oc_version: "4.13"
           overwrite: true          
           parameters:
-            -p ZONE=${{ env.ZONE }}    
+            -p ZONE=${{ env.ZONE }}
+            -p TAG=${{ github.event.number }}
 
       - name: Deploy Backend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -418,6 +430,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p TAG=${{ github.event.number }}
             -p PROMOTE=${{ github.repository }}/backend:${{ env.PREV }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
@@ -436,6 +449,7 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
+            -p TAG=${{ github.event.number }}
 
       - name: Deploy Frontend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -448,6 +462,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
+            -p TAG=${{ github.event.number }}
             -p PROMOTE=${{ github.repository }}/frontend:${{ env.PREV }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -173,7 +173,6 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Backend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -218,7 +217,6 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Frontend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -379,7 +377,6 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Backend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -411,7 +408,6 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ env.ZONE }}
-            -p TAG=${{ needs.vars.outputs.pr }}
 
       - name: Deploy Frontend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -145,6 +145,7 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
+            -p ENVIRONMENT=test
 
       - name: Deploy Processor
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -347,7 +348,8 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }}
             -p TAG=${{ needs.vars.outputs.pr }}
-            
+            -p ENVIRONMENT=prod
+
       - name: Deploy Processor
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
         with:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -25,21 +25,6 @@ jobs:
         id: pr
         uses: bcgov-nr/action-get-pr@v0.0.1
 
-  images-test:
-    name: Promote images to TEST
-    needs: [vars]
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        component: [backend, database, frontend, legacy, processor]
-    steps:
-      - uses: shrink/actions-docker-registry-tag@v4
-        with:
-          registry: ghcr.io
-          repository: ${{ github.repository }}/${{ matrix.component }}
-          target: ${{ needs.vars.outputs.pr }}
-          tags: test
-
   test-init:
     name: TEST Init
     needs: [images-test]
@@ -147,7 +132,6 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
             -p TAG=${{ env.ZONE }}
-            -p PROMOTE=${{ github.repository }}/database:${{ env.ZONE }}
 
       - name: Deploy Legacy
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -162,8 +146,6 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
             -p TAG=${{ env.ZONE }}
-            -p PROMOTE=${{ github.repository }}/legacy:${{ env.ZONE }}
-            -p ENVIRONMENT=${{ secrets.OC_NAMESPACE }}
 
       - name: Deploy Processor
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -177,7 +159,6 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
-            -p PROMOTE=${{ github.repository }}/processor:${{ env.ZONE }}
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
 
       - name: Deploy Backend ConfigMap
@@ -206,7 +187,6 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
             -p TAG=${{ env.ZONE }}
-            -p PROMOTE=${{ github.repository }}/backend:${{ env.ZONE }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
@@ -251,7 +231,6 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
             -p TAG=${{ env.ZONE }}
-            -p PROMOTE=${{ github.repository }}/frontend:${{ env.ZONE }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}
             -p URL=${{ env.URL }}
@@ -266,21 +245,6 @@ jobs:
   documentation:
     name: Generating Documentation
     uses: ./.github/workflows/reusable-doc-gen.yml
-
-  images-prod:
-    name: Promote images to PROD
-    needs: [test-deploy]
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        component: [backend, frontend, legacy, database, processor]
-    steps:
-      - uses: shrink/actions-docker-registry-tag@v4
-        with:
-          registry: ghcr.io
-          repository: ${{ github.repository }}/${{ matrix.component }}
-          target: test
-          tags: prod
 
   prod-init:
     name: PROD Init
@@ -387,7 +351,6 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
             -p TAG=${{ env.ZONE }}
-            -p PROMOTE=${{ github.repository }}/legacy:${{ env.PREV }}    
             
       - name: Deploy Processor
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -402,7 +365,6 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
             -p TAG=${{ env.ZONE }}
-            -p PROMOTE=${{ github.repository }}/processor:${{ env.PREV }}
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
 
       - name: Deploy Backend ConfigMap
@@ -431,7 +393,6 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
             -p TAG=${{ env.ZONE }}
-            -p PROMOTE=${{ github.repository }}/backend:${{ env.PREV }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
@@ -463,7 +424,6 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }} -p NAME=${{ github.event.repository.name }}
             -p TAG=${{ env.ZONE }}
-            -p PROMOTE=${{ github.repository }}/frontend:${{ env.PREV }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}
             -p URL=${{ env.URL }}
@@ -474,3 +434,18 @@ jobs:
             -p COGNITO_ENVIRONMENT=PROD
             -p LANDING_URL='${{ secrets.COGNITO_LOGOUT_URI }}'
             -p FRONTEND_URL=${{ env.URL }}
+
+  promote-images:
+    name: Promote images to PROD
+    needs: [prod-deploy]
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        component: [backend, frontend, legacy, database, common, processor]
+    steps:
+      - uses: shrink/actions-docker-registry-tag@v4
+        with:
+          registry: ghcr.io
+          repository: ${{ github.repository }}/${{ matrix.component }}
+          target: test
+          tags: prod

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -241,7 +241,6 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ github.event.number }}
-            -p TAG=${{ github.event.number }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
             -p ORACLEDB_USER_W=THE

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -240,6 +240,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ github.event.number }}
+            -p TAG=${{ github.event.number }}
             -p ORACLEDB_USER=${{ secrets.ORACLEDB_USERNAME }}
             -p ORACLEDB_PASSWORD=${{ secrets.ORACLEDB_PASSWORD }}
             -p ORACLEDB_USER_W=THE
@@ -309,6 +310,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ github.event.number }}
+            -p TAG=${{ github.event.number }}
             -p PROMOTE=${{ github.repository }}/legacy:${{ github.event.number }}
             -p ENVIRONMENT=${{ secrets.OC_NAMESPACE }}
             -p ORACLEDB_PORT=1521
@@ -325,6 +327,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ github.event.number }}
+            -p TAG=${{ github.event.number }}
             -p PROMOTE=${{ github.repository }}/processor:${{ github.event.number }}
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
 
@@ -335,10 +338,10 @@ jobs:
           oc_namespace: ${{ secrets.OC_NAMESPACE }}
           oc_server: ${{ secrets.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
-          oc_version: "4.13"
-          overwrite: true          
+          overwrite: true
           parameters:
-            -p ZONE=${{ github.event.number }}            
+            -p ZONE=${{ github.event.number }}
+            -p TAG=${{ github.event.number }}
 
       - name: Deploy Backend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -352,6 +355,7 @@ jobs:
           verification_path: health
           parameters:
             -p ZONE=${{ github.event.number }}
+            -p TAG=${{ github.event.number }}
             -p PROMOTE=${{ github.repository }}/backend:${{ github.event.number }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
@@ -368,7 +372,9 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           oc_version: "4.13"
           overwrite: true
-          parameters: -p ZONE=${{ github.event.number }}
+          parameters:
+            -p ZONE=${{ github.event.number }}
+            -p TAG=${{ github.event.number }}
 
       - name: Deploy Frontend ConfigMap
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -380,7 +386,8 @@ jobs:
           oc_version: "4.13"
           overwrite: true          
           parameters:
-            -p ZONE=${{ github.event.number }}  
+            -p ZONE=${{ github.event.number }}
+            -p TAG=${{ github.event.number }}
 
       - name: Deploy Frontend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -393,6 +400,7 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ github.event.number }}
+            -p TAG=${{ github.event.number }}
             -p PROMOTE=${{ github.repository }}/frontend:${{ github.event.number }}
             -p VITE_NODE_ENV=openshift-dev
             -p URL=${{ needs.vars.outputs.url }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -120,10 +120,12 @@ jobs:
             -p ORACLEDB_USER_W=THE
             -p ORACLEDB_PASSWORD_W=${{ secrets.ORACLEDB_PASSWORD_W }}
             -p TAG=latest
+
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
         with:        
           oc: "4.13"
+
       - name: Remove the PR database
         continue-on-error: true
         run: |

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: refs/heads/${{ github.event.repository.default_branch }}
+
       - name: Conventional Changelog Update
         uses: TriPSs/conventional-changelog-action@v5.4.0
         id: semver

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -253,6 +253,7 @@ jobs:
           parameters:
             -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
+            
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
         with:        

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -42,32 +42,31 @@ jobs:
           echo "semver=${{ steps.semver.outputs.tag }}"
           echo "url=${{ steps.calculate.outputs.url }}"
 
-  # builds:
-  #   name: Builds
-  #   runs-on: ubuntu-22.04
-  #   needs: [vars]
-  #   permissions:
-  #     packages: write
-  #   strategy:
-  #     matrix:
-  #       package: [backend, common, database, frontend, legacy, processor]
-  #   steps:
-  #     - uses: actions/checkout@v4
+  builds:
+    name: Builds
+    runs-on: ubuntu-22.04
+    needs: [vars]
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        package: [backend, common, database, frontend, legacy, processor]
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: bcgov-nr/action-builder-ghcr@v2.2.0
-  #       name: Build (${{ matrix.package }})
-  #       with:
-  #         package: ${{ matrix.package }}
-  #         tag: ${{ github.event.number }}
-  #         tag_fallback: test
-  #         triggers: ('${{ matrix.package }}/')
-  #         build_args: |
-  #           APP_VERSION=${{ needs.vars.outputs.semver }}-${{ github.event.number }}
+      - uses: bcgov-nr/action-builder-ghcr@v2.2.0
+        name: Build (${{ matrix.package }})
+        with:
+          package: ${{ matrix.package }}
+          tag: ${{ github.event.number }}
+          tag_fallback: test
+          triggers: ('${{ matrix.package }}/')
+          build_args: |
+            APP_VERSION=${{ needs.vars.outputs.semver }}-${{ github.event.number }}
 
   deploy:
     name: Deploy Application
-    # needs: [builds, vars]
-    needs: [vars]
+    needs: [builds, vars]
     environment: dev
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -296,6 +296,7 @@ jobs:
           parameters:
             -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
+            -p ENVIRONMENT=dev
 
       - name: Deploy Processor
         uses: bcgov-nr/action-deployer-openshift@v3.0.1

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -311,9 +311,6 @@ jobs:
           parameters:
             -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
-            -p PROMOTE=${{ github.repository }}/legacy:${{ github.event.number }}
-            -p ENVIRONMENT=${{ secrets.OC_NAMESPACE }}
-            -p ORACLEDB_PORT=1521
 
       - name: Deploy Processor
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -328,7 +325,6 @@ jobs:
           parameters:
             -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
-            -p PROMOTE=${{ github.repository }}/processor:${{ github.event.number }}
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
 
       - name: Deploy Backend ConfigMap
@@ -356,7 +352,6 @@ jobs:
           parameters:
             -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
-            -p PROMOTE=${{ github.repository }}/backend:${{ github.event.number }}
             -p CHES_TOKEN_URL='https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token'
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
@@ -401,7 +396,6 @@ jobs:
           parameters:
             -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
-            -p PROMOTE=${{ github.repository }}/frontend:${{ github.event.number }}
             -p VITE_NODE_ENV=openshift-dev
             -p URL=${{ needs.vars.outputs.url }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -257,6 +257,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:        
           oc: "4.13"
+
       - name: Backup database before update
         continue-on-error: true
         run: |
@@ -350,7 +351,6 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ github.event.number }}
-            -p TAG=${{ github.event.number }}
 
       - name: Deploy Frontend ConfigMap
         uses: bcgov-nr/action-deployer-openshift@v3.0.1

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -97,7 +97,7 @@ jobs:
 
   deploy-tools:
     name: Deploy Tools
-    needs: [pre-tools, build-legacydb, vars]
+    needs: [pre-tools, vars]
     environment: tools
     env:
       DOMAIN: apps.silver.devops.gov.bc.ca

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -42,50 +42,32 @@ jobs:
           echo "semver=${{ steps.semver.outputs.tag }}"
           echo "url=${{ steps.calculate.outputs.url }}"
 
-  builds:
-    name: Builds
-    runs-on: ubuntu-24.04
+  # builds:
+  #   name: Builds
+  #   runs-on: ubuntu-22.04
+  #   needs: [vars]
+  #   permissions:
+  #     packages: write
+  #   strategy:
+  #     matrix:
+  #       package: [backend, common, database, frontend, legacy, processor]
+  #   steps:
+  #     - uses: actions/checkout@v4
+
+  #     - uses: bcgov-nr/action-builder-ghcr@v2.2.0
+  #       name: Build (${{ matrix.package }})
+  #       with:
+  #         package: ${{ matrix.package }}
+  #         tag: ${{ github.event.number }}
+  #         tag_fallback: test
+  #         triggers: ('${{ matrix.package }}/')
+  #         build_args: |
+  #           APP_VERSION=${{ needs.vars.outputs.semver }}-${{ github.event.number }}
+
+  deploy:
+    name: Deploy Application
+    # needs: [builds, vars]
     needs: [vars]
-    permissions:
-      packages: write
-    strategy:
-      matrix:
-        package: [backend, database, frontend, legacy, processor]
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: bcgov-nr/action-builder-ghcr@v2.2.0
-        name: Build (${{ matrix.package }})
-        with:
-          package: ${{ matrix.package }}
-          tag: ${{ github.event.number }}
-          tag_fallback: test
-          triggers: ('${{ matrix.package }}/')
-          build_args: |
-            APP_VERSION=${{ needs.vars.outputs.semver }}-${{ github.event.number }}
-
-  build-legacydb:
-    name: Builds (legacydb)
-    runs-on: ubuntu-24.04
-    needs: [vars]
-    permissions:
-      packages: write    
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: bcgov-nr/action-builder-ghcr@v2.2.0
-        name: Build (Legacy db)
-        with:
-          package: legacydb
-          tag: latest
-          tag_fallback: test
-          triggers: ('legacydb/')
-          build_args: |
-            APP_VERSION=${{ needs.vars.outputs.semver }}-${{ github.event.number }}
-
-  pre-tools:
-    name: Pre Deploy Tools
-    needs: [build-legacydb, vars]
     environment: dev
     runs-on: ubuntu-24.04
     steps:
@@ -337,7 +319,6 @@ jobs:
           overwrite: true
           parameters:
             -p ZONE=${{ github.event.number }}
-            -p TAG=${{ github.event.number }}
 
       - name: Deploy Backend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -382,7 +363,6 @@ jobs:
           overwrite: true          
           parameters:
             -p ZONE=${{ github.event.number }}
-            -p TAG=${{ github.event.number }}
 
       - name: Deploy Frontend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -64,8 +64,8 @@ jobs:
           build_args: |
             APP_VERSION=${{ needs.vars.outputs.semver }}-${{ github.event.number }}
 
-  deploy:
-    name: Deploy Application
+  pre-tools:
+    name: Pre Deploy Tools
     needs: [builds, vars]
     environment: dev
     runs-on: ubuntu-24.04

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -27,9 +27,6 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
-  - name: PROMOTE
-    description: Image (namespace/name:tag) to promote/import
-    value: bcgov/nr-forest-client-backend:prod
   - name: CHES_TOKEN_URL
     description: CHES service authentication url
     required: true

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -67,28 +67,19 @@ objects:
             name: ${REGISTRY}/${PROMOTE}
           referencePolicy:
             type: Local
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       labels:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           annotations:
@@ -97,7 +88,7 @@ objects:
             prometheus.io/path: "/metrics"
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           volumes:
             - name: ${COMPONENT}-config
@@ -236,7 +227,7 @@ objects:
           port: 80
           targetPort: 8080
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
   - kind: Route
     apiVersion: route.openshift.io/v1
     metadata:

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -53,6 +53,10 @@ parameters:
   - name: CONFIG_MAP_NAME
     description: ConfigMap name specific to each environment
     value: ${NAME}-${ZONE}-${COMPONENT}-config
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
   - kind: Deployment
     apiVersion: apps/v1
@@ -181,6 +185,8 @@ objects:
                   value: ${COMPONENT}
                 - name: FEATURES_BCREGISTRY_MULTIADDRESS
                   value: "false"
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               ports:
                 - containerPort: 8080
                   protocol: TCP

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -13,9 +13,15 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: IMAGE_TAG
-    description: Image tag to use
-    value: latest
+  - name: TAG
+    description: Image tag; e.g. PR number, latest or prod
+    required: true
+  - name: REGISTRY
+    description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
+    value: ghcr.io
+  - name: ORG
+    description: Organization name
+    value: bcgov
   - name: DOMAIN
     value: apps.silver.devops.gov.bc.ca
   - name: REGISTRY
@@ -51,22 +57,6 @@ parameters:
     description: ConfigMap name specific to each environment
     value: ${NAME}-${ZONE}-${COMPONENT}-config
 objects:
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: ${IMAGE_TAG}
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${PROMOTE}
-          referencePolicy:
-            type: Local
   - kind: Deployment
     apiVersion: apps/v1
     metadata:
@@ -95,7 +85,7 @@ objects:
               configMap:
                 name: ${NAME}-${ZONE}-${COMPONENT}-config
           containers:
-            - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
+            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}
               imagePullPolicy: Always
               name: ${NAME}
               volumeMounts:

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -91,6 +91,10 @@ parameters:
     description: Random expression to make sure deployments update
     from: "[a-zA-Z0-9]{32}"
     generate: expression
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
   - kind: PersistentVolumeClaim
     apiVersion: v1

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -33,9 +33,6 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
-  - name: PROMOTE
-    description: Image (namespace/name:tag) to promote/import
-    value: bcgov/nr-old-growth:prod-frontend
   - name: CPU_REQUEST
     value: 10m
   - name: CPU_LIMIT

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -111,28 +111,19 @@ objects:
         window.localStorage.setItem('VITE_LOGOUT_BCSC_URL','${LANDING_URL}');
         window.localStorage.setItem('VITE_LOGOUT_BCEIDBUSINESS_URL','${LANDING_URL}');
         window.localStorage.setItem('VITE_LOGOUT_IDIR_URL','https://${URL}');
-  - kind: DeploymentConfig
-    apiVersion: v1    
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       labels:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           annotations:
@@ -141,7 +132,7 @@ objects:
             prometheus.io/path: "/metrics"
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           volumes:
             - name: app-config
@@ -216,7 +207,7 @@ objects:
           port: 80
           targetPort: 3000
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
   - kind: Route
     apiVersion: route.openshift.io/v1    
     metadata:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -19,9 +19,15 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: IMAGE_TAG
-    description: Image tag to use
-    value: latest
+  - name: TAG
+    description: Image tag; e.g. PR number, latest or prod
+    required: true
+  - name: REGISTRY
+    description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
+    value: ghcr.io
+  - name: ORG
+    description: Organization name
+    value: bcgov
   - name: DOMAIN
     value: apps.silver.devops.gov.bc.ca
   - name: REGISTRY
@@ -75,22 +81,6 @@ parameters:
     required: true
 objects:
 objects:
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: ${IMAGE_TAG}
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${PROMOTE}
-          referencePolicy:
-            type: Local
   - kind: ConfigMap
     apiVersion: v1
     metadata:
@@ -142,7 +132,7 @@ objects:
               configMap:
                 name: ${NAME}-${ZONE}-${COMPONENT}-config
           containers:
-            - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
+            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}
               securityContext:
                 capabilities:
                   add: ["NET_BIND_SERVICE"]

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -76,6 +76,10 @@ parameters:
   - name: FRONTEND_URL
     description: Frontend URL
     required: true
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
 objects:
   - kind: ConfigMap
@@ -144,6 +148,8 @@ objects:
                   value: ${COGNITO_REGION}
                 - name: COGNITO_DOMAIN
                   value: ${COGNITO_DOMAIN}
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               imagePullPolicy: Always
               name: ${NAME}
               volumeMounts:

--- a/legacy/openshift.deploy.yml
+++ b/legacy/openshift.deploy.yml
@@ -13,12 +13,15 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: ENVIRONMENT
-    description: Environment name used by the application
-    value: prod
-  - name: IMAGE_TAG
-    description: Image tag to use
-    value: latest
+  - name: TAG
+    description: Image tag; e.g. PR number, latest or prod
+    required: true
+  - name: REGISTRY
+    description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
+    value: ghcr.io
+  - name: ORG
+    description: Organization name
+    value: bcgov
   - name: DOMAIN
     value: apps.silver.devops.gov.bc.ca
   - name: REGISTRY
@@ -44,22 +47,6 @@ parameters:
     description: The amount of storage the cert PVC should have
     value: 25Mi
 objects:  
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: ${IMAGE_TAG}
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${PROMOTE}
-          referencePolicy:
-            type: Local
   - kind: PersistentVolumeClaim
     apiVersion: v1
     metadata:
@@ -129,7 +116,7 @@ objects:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
           containers:
-            - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
+            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}
               imagePullPolicy: Always
               name: ${NAME}
               env:

--- a/legacy/openshift.deploy.yml
+++ b/legacy/openshift.deploy.yml
@@ -73,8 +73,8 @@ objects:
         requests:
           storage: ${CERT_PVC_SIZE}
       storageClassName: netapp-file-standard
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       labels:
         app: ${NAME}-${ZONE}
@@ -82,20 +82,11 @@ objects:
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           annotations:
@@ -104,7 +95,7 @@ objects:
             prometheus.io/path: "/metrics"
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           volumes:
             - name: ${NAME}-${ZONE}-certs
@@ -226,4 +217,4 @@ objects:
           port: 80
           targetPort: 9000
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/legacy/openshift.deploy.yml
+++ b/legacy/openshift.deploy.yml
@@ -149,7 +149,7 @@ objects:
                 - name: ORACLEDB_PORT
                   value: ${ORACLEDB_PORT}
                 - name: SPRING_PROFILES_ACTIVE
-                  value: "container,${ENVIRONMENT}"
+                  value: "container,${ZONE}"
                 - name: ORACLEDB_SECRET
                   valueFrom:
                     secretKeyRef:

--- a/legacy/openshift.deploy.yml
+++ b/legacy/openshift.deploy.yml
@@ -13,6 +13,9 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
+  - name: ENVIRONMENT
+    description: Environment name used by the application
+    required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
     required: true
@@ -149,7 +152,7 @@ objects:
                 - name: ORACLEDB_PORT
                   value: ${ORACLEDB_PORT}
                 - name: SPRING_PROFILES_ACTIVE
-                  value: "container,${ZONE}"
+                  value: "container,${ENVIRONMENT}"
                 - name: ORACLEDB_SECRET
                   valueFrom:
                     secretKeyRef:

--- a/legacy/openshift.deploy.yml
+++ b/legacy/openshift.deploy.yml
@@ -43,6 +43,10 @@ parameters:
   - name: CERT_PVC_SIZE
     description: The amount of storage the cert PVC should have
     value: 25Mi
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:  
   - kind: PersistentVolumeClaim
     apiVersion: v1
@@ -155,6 +159,8 @@ objects:
                   value: /cert/jssecacerts
                 - name: TZ
                   value: America/Vancouver
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               ports:
                 - containerPort: 9000
                   protocol: TCP

--- a/legacy/openshift.deploy.yml
+++ b/legacy/openshift.deploy.yml
@@ -27,9 +27,6 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
-  - name: PROMOTE
-    description: Image (namespace/name:tag) to promote/import
-    value: bcgov/nr-forest-client-legacy:prod
   - name: ORACLEDB_KEYSTORE
     description: Oracle database keystore file
   - name: ORACLEDB_PORT

--- a/processor/openshift.deploy.yml
+++ b/processor/openshift.deploy.yml
@@ -52,28 +52,19 @@ objects:
             name: ${REGISTRY}/${PROMOTE}
           referencePolicy:
             type: Local
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       labels:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           annotations:
@@ -82,7 +73,7 @@ objects:
             prometheus.io/path: "/metrics"
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
             - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
@@ -169,4 +160,4 @@ objects:
           port: 80
           targetPort: 3100
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/processor/openshift.deploy.yml
+++ b/processor/openshift.deploy.yml
@@ -13,9 +13,15 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: IMAGE_TAG
-    description: Image tag to use
-    value: latest
+  - name: TAG
+    description: Image tag; e.g. PR number, latest or prod
+    required: true
+  - name: REGISTRY
+    description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
+    value: ghcr.io
+  - name: ORG
+    description: Organization name
+    value: bcgov
   - name: DOMAIN
     value: apps.silver.devops.gov.bc.ca
   - name: REGISTRY
@@ -36,22 +42,7 @@ parameters:
     description: Bc Registry API address
     required: true
 objects:
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: ${IMAGE_TAG}
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${PROMOTE}
-          referencePolicy:
-            type: Local
+
   - kind: Deployment
     apiVersion: apps/v1
     metadata:
@@ -76,7 +67,7 @@ objects:
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
-            - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
+            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}
               imagePullPolicy: Always
               name: ${NAME}
               env:

--- a/processor/openshift.deploy.yml
+++ b/processor/openshift.deploy.yml
@@ -38,6 +38,10 @@ parameters:
   - name: BCREGISTRY_URI
     description: Bc Registry API address
     required: true
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
 
   - kind: Deployment
@@ -115,6 +119,8 @@ objects:
                     secretKeyRef:
                       name: ${NAME}-${ZONE}
                       key: processor-service-account-secret
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               ports:
                 - containerPort: 3000
                   protocol: TCP

--- a/processor/openshift.deploy.yml
+++ b/processor/openshift.deploy.yml
@@ -27,9 +27,6 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
-  - name: PROMOTE
-    description: Image (namespace/name:tag) to promote/import
-    value: bcgov/nr-old-growth:prod-backend
   - name: CPU_REQUEST
     value: 75m
   - name: CPU_LIMIT


### PR DESCRIPTION
Replaces deprecated Deployment Configs with Deployments. Also removes image streams and uses a randomly generated envar to ensure consistent rollouts.

Unfortunately there will be some downtime when this deploys.

Steps:
- Delete deployment configs and services for TEST database and backend
- Delete deployment configs and services for PROD database and backend
- Merge this PR
- Let deployments to TEST and PROD complete

Closes #1123.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-26-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)