### PR TITLE
fix(fe): display simultaneous error and warning

### DIFF
--- a/frontend/cypress/e2e/pages/FormStaffPageFuzzy.cy.ts
+++ b/frontend/cypress/e2e/pages/FormStaffPageFuzzy.cy.ts
@@ -217,6 +217,62 @@ describe("Staff Form Fuzzy Matches", () => {
 
     });
 
+    it('should have individual data with fuzzy resulting in Step 1: full and partial individual match', () => {
+      fillIndividual();
+      clickNext(1);
+
+      checkTopNotification('error', 'has client number');
+
+      /*
+      The following group of fields has both warning and error.
+      In this case they are displayed as error.
+      They are from both the full and the partial matches.
+      */
+      checkInputError('#firstName');
+      checkInputError('#lastName');
+      checkInputError('#birthdateYear');
+      checkInputError('#birthdateMonth');
+      checkInputError('#birthdateDay');
+
+      checkDropdownClean('#identificationType');
+      checkDropdownClean('#identificationProvince');
+
+      // From the full match
+      checkInputError('#clientIdentification');
+
+      cy.get("[data-test='wizard-next-button']")
+      .shadow()
+      .find("button")
+      .should("be.disabled");
+
+      cy.get('#reviewStatement').should('not.exist');
+    });
+
+    it('should have individual data with fuzzy resulting in Step 1: document and partial individual match', () => {
+      fillIndividual();
+      clickNext(1);
+
+      checkTopNotification('error', 'has client number');
+
+      // The partial match (warning)
+      checkInputWarning('#firstName');
+      checkInputWarning('#lastName');
+      checkInputWarning('#birthdateYear');
+      checkInputWarning('#birthdateMonth');
+      checkInputWarning('#birthdateDay');
+
+      // The document match (error)
+      checkDropdownError('#identificationType');
+      checkDropdownError('#identificationProvince');
+      checkInputError('#clientIdentification');
+
+      cy.get("[data-test='wizard-next-button']")
+      .shadow()
+      .find("button")
+      .should("be.disabled");
+
+      cy.get('#reviewStatement').should('not.exist');
+    });
   });
 
   describe('BC Registered fuzzy matching',() =>{

--- a/frontend/cypress/fixtures/fuzzy/document_and_partial_individual_match.json
+++ b/frontend/cypress/fixtures/fuzzy/document_and_partial_individual_match.json
@@ -1,0 +1,20 @@
+{
+  "statusCode": 409,
+  "headers": {
+    "content-type": "application/json;charset=UTF-8"
+  },
+  "body":[
+    {
+      "field":"businessInformation.individual", 
+      "match":"00000001", 
+      "fuzzy":true,
+      "partialMatch":true
+    },
+    {
+      "field":"businessInformation.clientIdentification", 
+      "match":"00000002", 
+      "fuzzy":false,
+      "partialMatch":false
+    }
+  ]
+}

--- a/frontend/cypress/fixtures/fuzzy/full_and_partial_individual_match.json
+++ b/frontend/cypress/fixtures/fuzzy/full_and_partial_individual_match.json
@@ -1,0 +1,21 @@
+{
+  "statusCode": 409,
+  "headers": {
+    "content-type": "application/json;charset=UTF-8"
+  },
+  "body":[
+    {
+      "comment":"it seems like the partial one is always the first returned by the real API",
+      "field":"businessInformation.individual", 
+      "match":"00000001", 
+      "fuzzy":true,
+      "partialMatch":true
+    },
+    {
+      "field":"businessInformation.individualAndDocument", 
+      "match":"00000001", 
+      "fuzzy":false,
+      "partialMatch":false
+    }
+  ]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,8 @@
     "test:report:clean": "rm -rf reports && mkdir -p reports/.nyc_output/processinfo && mkdir -p coverage",
     "test:build": "cross-env VITE_MODE=test VITE_NODE_ENV=test VITE_FEATURE_FLAGS={\\\"STAFF_CREATE\\\":true} start-server-and-test preview http://127.0.0.1:3000 'cypress open'",
     "test:flush": "rm -rf reports && rm -rf .nyc_output && rm -rf coverage && rm -rf reports-merge",
-    "posttest:flush": "npm run coverage"
+    "posttest:flush": "npm run coverage",
+    "test:unit:devtools": "cross-env VITE_NODE_ENV=test NODE_ENV=test vitest run --inspect-brk --pool threads --poolOptions.threads.singleThread"
   },
   "dependencies": {
     "@bcgov-nr/nr-fsa-theme": "^1.1.3",

--- a/frontend/stub/__files/fuzzy/document_and_partial_individual_match.json
+++ b/frontend/stub/__files/fuzzy/document_and_partial_individual_match.json
@@ -10,5 +10,5 @@
     "match":"00000002", 
     "fuzzy":false,
     "partialMatch":false
-  }  
+  }
 ]

--- a/frontend/stub/__files/fuzzy/full_and_partial_individual_match.json
+++ b/frontend/stub/__files/fuzzy/full_and_partial_individual_match.json
@@ -1,5 +1,6 @@
 [
   {
+    "comment":"it seems like the partial one is always the first returned by the real API",
     "field":"businessInformation.individual", 
     "match":"00000001", 
     "fuzzy":true,
@@ -10,5 +11,5 @@
     "match":"00000001", 
     "fuzzy":false,
     "partialMatch":false
-  }  
+  }
 ]

--- a/frontend/stub/mappings/fuzzy_matches.json
+++ b/frontend/stub/mappings/fuzzy_matches.json
@@ -61,7 +61,7 @@
       }
     },
     {
-      "name": "Submission Fuzzy for Individuals: Full Match",
+      "name": "Submission Fuzzy for Individuals: Full and Partial Match",
       "request": {
         "url": "/api/clients/matches",
         "method": "POST",
@@ -108,7 +108,7 @@
       },
       "response": {
         "status": 409,
-        "bodyFileName": "fuzzy/full_individual_match.json",
+        "bodyFileName": "fuzzy/full_and_partial_individual_match.json",
         "headers": { "Content-Type": "application/json" }
       }
     },
@@ -159,7 +159,7 @@
       }
     },
     {
-      "name": "Submission Fuzzy for Individuals: Both Match",
+      "name": "Submission Fuzzy for Individuals: Document and Partial Match",
       "request": {
         "url": "/api/clients/matches",
         "method": "POST",
@@ -206,7 +206,7 @@
       },
       "response": {
         "status": 409,
-        "bodyFileName": "fuzzy/full_individual_doc_match.json",
+        "bodyFileName": "fuzzy/document_and_partial_individual_match.json",
         "headers": { "Content-Type": "application/json" }
       }
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

When a field has both a full (error) and a partial (warning) match, render the field using the error style.
Also renames some stubs to make it clearer.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-27-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-27-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)