### PR TITLE
fix(fe: FSADT1-1448): Button Next gets disabled if the Province is changed

### DIFF
--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -156,6 +156,16 @@ Cypress.Commands.add("fillFormEntry",(field: string, value: string, delayMS: num
   .blur();
 });
 
+Cypress.Commands.add("clearFormEntry",(field: string, area: boolean = false) =>{
+  cy.get(field)
+  .should("exist")
+  .shadow()
+  .find(area ? "textarea" : "input")
+  .focus()
+  .clear()
+  .blur();
+});
+
 Cypress.Commands.add("selectFormEntry", (field: string, value: string, box: boolean) => {
   cy.get(field).find("[part='trigger-button']").click();
 

--- a/frontend/cypress/support/cypress.d.ts
+++ b/frontend/cypress/support/cypress.d.ts
@@ -10,6 +10,7 @@ declare namespace Cypress {
     logout(): Chainable<void>;
     getMany(names: string[]): Chainable<any[]>;
     fillFormEntry(field: string, value: string, delayMS: number = 10, area: boolean = false): Chainable<void>;
+    clearFormEntry(field: string, area: boolean = false): Chainable<void>;
     selectFormEntry(field: string, value: string, box: boolean): Chainable<void>;
     selectAutocompleteEntry(field: string, value: string, dataid: string, delayTarget: string =''): Chainable<void>;
     checkInputErrorMessage(field: string, message: string): Chainable<void>;

--- a/frontend/tests/components/pages/staffform/IndividualClientInformationWizardStep.cy.ts
+++ b/frontend/tests/components/pages/staffform/IndividualClientInformationWizardStep.cy.ts
@@ -447,6 +447,7 @@ describe("<individual-client-information-wizard-step />", () => {
           });
           describe("and the ID number is properly filled in", () => {
             beforeEach(() => {
+              cy.clearFormEntry("#clientIdentification");
               cy.get("#clientIdentification").shadow().find("input").type("12345678");
 
               cy.get("#clientIdentification").shadow().find("input").blur();

--- a/frontend/tests/components/pages/staffform/IndividualClientInformationWizardStep.cy.ts
+++ b/frontend/tests/components/pages/staffform/IndividualClientInformationWizardStep.cy.ts
@@ -468,6 +468,74 @@ describe("<individual-client-information-wizard-step />", () => {
           });
         });
       });
+
+      describe("and the ID number gets filled in", () => {
+        beforeEach(() => {
+          cy.clearFormEntry("#clientIdentification");
+          cy.fillFormEntry("#clientIdentification", "1234567");
+          cy.wait(1);
+        });
+
+        describe("and the Issuing province is changed", () => {
+          beforeEach(() => {
+            cy.selectFormEntry("#identificationProvince", "Manitoba", false);
+            cy.wait(1);
+          });
+
+          it("should emit valid true", () => {
+            /*
+            This test makes sure the impact of clearing the province (and thus making the
+            province field invalid) does not matter anymore after we get to a situation where the
+            province field is not used.
+            */
+            cy.get("@vueWrapper").should((vueWrapper) => {
+              const lastValid = vueWrapper.emitted("valid").slice(-1)[0];
+
+              // Last event (in)"valid" emitted
+              expect(lastValid[0]).to.equal(true);
+            });
+          });
+        });
+      });
+
+      describe("and the Issuing province is changed to Manitoba", () => {
+        beforeEach(() => {
+          cy.selectFormEntry("#identificationProvince", "Manitoba", false);
+        });
+
+        describe("and the ID number gets filled in with numbers and letters", () => {
+          beforeEach(() => {
+            cy.clearFormEntry("#clientIdentification");
+            cy.fillFormEntry("#clientIdentification", "1234567A");
+            cy.wait(1);
+          });
+
+          it("should emit valid true", () => {
+            cy.get("@vueWrapper").should((vueWrapper) => {
+              const lastValid = vueWrapper.emitted("valid").slice(-1)[0];
+
+              // Last event (in)"valid" emitted
+              expect(lastValid[0]).to.equal(true);
+            });
+          });
+
+          describe("and the Issuing province is changed to BC", () => {
+            beforeEach(() => {
+              cy.selectFormEntry("#identificationProvince", "British Columbia", false);
+              cy.wait(1);
+            });
+
+            it("should emit valid false because letters are not allowed for BC driver's licence", () => {
+              cy.get("@vueWrapper").should((vueWrapper) => {
+                const lastValid = vueWrapper.emitted("valid").slice(-1)[0];
+
+                // Last event (in)"valid" emitted
+                expect(lastValid[0]).to.equal(false);
+              });
+            });
+          });
+        });
+      });
     });
   });
 });

--- a/frontend/tests/components/pages/staffform/IndividualClientInformationWizardStep.cy.ts
+++ b/frontend/tests/components/pages/staffform/IndividualClientInformationWizardStep.cy.ts
@@ -483,12 +483,7 @@ describe("<individual-client-information-wizard-step />", () => {
             cy.wait(1);
           });
 
-          it("should emit valid true", () => {
-            /*
-            This test makes sure the impact of clearing the province (and thus making the
-            province field invalid) does not matter anymore after we get to a situation where the
-            province field is not used.
-            */
+          it("should emit valid true since the supplied driver's licence ID is also valid for Manitoba", () => {
             cy.get("@vueWrapper").should((vueWrapper) => {
               const lastValid = vueWrapper.emitted("valid").slice(-1)[0];
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Revalidates the id number after changing the province, so the button next is kept enabled if the supplied id number is valid for the newly selected province.

Fixes [FSADT1-1448](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT1-1448)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-28-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-28-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)