### PR TITLE
fix(fe: FSADT1-1427): Autocomplete emitting value twice

### DIFF
--- a/frontend/src/components/forms/AutoCompleteInputComponent.vue
+++ b/frontend/src/components/forms/AutoCompleteInputComponent.vue
@@ -90,14 +90,15 @@ const inputList = computed<Array<BusinessSearchResult>>(() => {
   return [];
 });
 
-let selectedValue: BusinessSearchResult | undefined = undefined;
-
 //This function emits the events on update
-const emitValueChange = (newValue: string): void => {
-  // Prevent selecting the empty value included when props.contents is empty.
-  selectedValue = newValue
-    ? inputList.value.find((entry) => entry.code === newValue)
-    : undefined;
+const emitValueChange = (newValue: string, isSelectEvent = false): void => {
+  let selectedValue: BusinessSearchResult | undefined;
+  if (isSelectEvent) {
+    // Prevent selecting the empty value included when props.contents is empty.
+    selectedValue = newValue
+      ? inputList.value.find((entry) => entry.code === newValue)
+      : undefined;
+  }
 
   emit("update:model-value", selectedValue?.name ?? newValue);
   emit("update:selected-value", selectedValue);
@@ -124,7 +125,9 @@ watch(
   }
 );
 watch([inputValue], () => {
-  emitValueChange(inputValue.value);
+  if (isUserEvent.value) {
+    emitValueChange(inputValue.value);
+  }
 });
 
 /**
@@ -168,7 +171,7 @@ const validateInput = (newValue: string) => {
 
 const selectAutocompleteItem = (event: any) => {
   const newValue = event?.detail?.item?.getAttribute("data-id");
-  emitValueChange(newValue);
+  emitValueChange(newValue, true);
   validateInput(newValue);
 };
 

--- a/frontend/src/pages/staffform/FirstNationClientInformationWizardStep.vue
+++ b/frontend/src/pages/staffform/FirstNationClientInformationWizardStep.vue
@@ -75,11 +75,6 @@ watch([autoCompleteResult], () => {
   firstNationControl.value = false;
 });
 
-const updateModelValue = ($event) => {
-  validation.businessName =
-    !!$event && $event === autoCompleteResult.value?.name;
-};
-
 const parseSelectedNation = (
   selectedNation: FirstNationDetailsDto
 ) => {
@@ -129,7 +124,7 @@ const mapFirstNationInfo = (firstNations: ForestClientDetailsDto[] = []) => {
         enabled
         :loading="loading"
         @update:selected-value="autoCompleteResult = parseSelectedNation($event)"
-        @update:model-value="updateModelValue"
+        @update:model-value="validation.businessName = false"
       />
       <cds-inline-loading status="active" v-if="loading">Loading first nation details...</cds-inline-loading>
     </data-fetcher>

--- a/frontend/tests/unittests/components/forms/AutoCompleteInputComponent.spec.ts
+++ b/frontend/tests/unittests/components/forms/AutoCompleteInputComponent.spec.ts
@@ -223,12 +223,28 @@ describe("Auto Complete Input Component", () => {
 
     it('emits the "update:selected-value" with undefined when user types something in the input field', async () => {
       // adding a 'Z' character to the end of the original value so to trigger an update:model-value
-      await wrapper.setProps({ modelValue: "TANGOZ" });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      wrapper.find<CDSComboBox>(`#${id}`).element._filterInputValue = "TANGOZ";
+      await wrapper.find(`#${id}`).trigger("input");
 
       expect(wrapper.emitted("update:selected-value")).toHaveLength(2);
       expect(wrapper.emitted("update:selected-value")![1][0]).toEqual(
         undefined
       );
+    });
+
+    it('doesn\'t emit the "update:selected-value" when the value has been changed from outside', async () => {
+      const expectedCount = 1;
+
+      // Expected count before the update
+      expect(wrapper.emitted("update:selected-value")).toHaveLength(expectedCount);
+
+      // adding a 'Z' character to the end of the original value so to trigger an update:model-value
+      await wrapper.setProps({ modelValue: "TANGOZ" });
+
+      // Expected count after the update
+      expect(wrapper.emitted("update:selected-value")).toHaveLength(expectedCount);
     });
 
     it('emits the "update:selected-value" with the newly selected value', async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Prevents the Autocomplete component from re-emitting with value undefined after a selection.

Fixes [FSADT1-1427](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT1-1427)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-20-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)