### PR TITLE
fix(fe:FSADT1-1508): reset validation when the selected Client name changes

### DIFF
--- a/frontend/cypress/e2e/pages/staffform/BcRegisteredClientInformationWizardStep.cy.ts
+++ b/frontend/cypress/e2e/pages/staffform/BcRegisteredClientInformationWizardStep.cy.ts
@@ -680,6 +680,105 @@ describe("BC Registered Staff Wizard Step", () => {
     });
   });
 
+  describe("when the selected Client name is a Sole proprietorship", () => {
+    beforeEach(() => {
+      loginAndNavigateToStaffForm();
+
+      cy.get("cds-inline-notification#bcRegistrySearchNotification").should("exist");
+
+      const sppSearch = "spp";
+      const sppCode = "FM123123";
+
+      interceptClientsApi(sppSearch, sppCode);
+
+      cy.selectAutocompleteEntry("#businessName", sppSearch, sppCode, `@clientSearch${sppSearch}`);
+
+      cy.get(".read-only-box > #legalType")
+        .should("exist")
+        .and("contains.text", "Sole Proprietorship");
+    });
+    it("should not enable the button Next while Date of birth is empty", () => {
+      cy.get("[data-test='wizard-next-button']").find("button").should("be.disabled");
+    });
+    it("should enable the button Next when Date of birth is filled in", () => {
+      cy.fillFormEntry("#birthdateYear", "2001");
+      cy.fillFormEntry("#birthdateMonth", "10");
+      cy.fillFormEntry("#birthdateDay", "25");
+      cy.get("[data-test='wizard-next-button']").find("button").should("be.enabled");
+    });
+    describe("and there is an error on the Date of birth", () => {
+      beforeEach(() => {
+        cy.get("#birthdateYear").find("input").focus().blur();
+
+        cy.contains("#birthdate + .field-error", "Date of birth must include a year");
+      });
+      it("enables the button Next when a new Client name from a different type gets selected", () => {
+        cy.clearFormEntry("#businessName");
+
+        const cmpSearch = "cmp";
+        const cmpCode = "C1231231";
+
+        interceptClientsApi(cmpSearch, cmpCode);
+
+        cy.selectAutocompleteEntry(
+          "#businessName",
+          cmpSearch,
+          cmpCode,
+          `@clientSearch${cmpSearch}`,
+        );
+
+        cy.get(".read-only-box > #legalType")
+          .should("exist")
+          .and("contains.text", "Continued In Corporation");
+
+        cy.get("[data-test='wizard-next-button']").find("button").should("be.enabled");
+      });
+    });
+  });
+
+  describe("when the selected Client name is not a Sole proprietorship and there is an error on the Doing business as", () => {
+    beforeEach(() => {
+      loginAndNavigateToStaffForm();
+
+      cy.get("cds-inline-notification#bcRegistrySearchNotification").should("exist");
+
+      const cmpSearch = "cmp";
+      const cmpCode = "C1231231";
+
+      interceptClientsApi(cmpSearch, cmpCode);
+
+      cy.selectAutocompleteEntry("#businessName", cmpSearch, cmpCode, `@clientSearch${cmpSearch}`);
+
+      cy.get(".read-only-box > #legalType")
+        .should("exist")
+        .and("contains.text", "Continued In Corporation");
+
+      cy.fillFormEntry("#doingBusinessAs", "Enchanté");
+
+      cy.checkInputErrorMessage("#doingBusinessAs", "The doing business as can only contain");
+    });
+    it("enables the button Next when a new Client name with type Sole proprietorship gets selected", () => {
+      cy.clearFormEntry("#businessName");
+
+      const sppSearch = "spp";
+      const sppCode = "FM123123";
+
+      interceptClientsApi(sppSearch, sppCode);
+
+      cy.selectAutocompleteEntry("#businessName", sppSearch, sppCode, `@clientSearch${sppSearch}`);
+
+      cy.get(".read-only-box > #legalType")
+        .should("exist")
+        .and("contains.text", "Sole Proprietorship");
+
+      cy.fillFormEntry("#birthdateYear", "2001");
+      cy.fillFormEntry("#birthdateMonth", "10");
+      cy.fillFormEntry("#birthdateDay", "23");
+
+      cy.get("[data-test='wizard-next-button']").find("button").should("be.enabled");
+    });
+  });
+
   const loginAndNavigateToStaffForm = () => {
     cy.visit("/");
 

--- a/frontend/cypress/support/cypress.d.ts
+++ b/frontend/cypress/support/cypress.d.ts
@@ -12,8 +12,8 @@ declare namespace Cypress {
     fillFormEntry(field: string, value: string, delayMS: number = 10, area: boolean = false): Chainable<void>;
     clearFormEntry(field: string, area: boolean = false): Chainable<void>;
     selectFormEntry(field: string, value: string, box: boolean): Chainable<void>;
-    checkFormEntry(field: string): Chainable<void>;
-    uncheckFormEntry(field: string): Chainable<void>;
+    markCheckbox(field: string): Chainable<void>;
+    unmarkCheckbox(field: string): Chainable<void>;
     selectAutocompleteEntry(field: string, value: string, dataid: string, delayTarget: string =''): Chainable<void>;
     checkInputErrorMessage(field: string, message: string): Chainable<void>;
     checkAutoCompleteErrorMessage(field: string, message: string): Chainable<void>;

--- a/frontend/src/pages/staffform/BcRegisteredClientInformationWizardStep.vue
+++ b/frontend/src/pages/staffform/BcRegisteredClientInformationWizardStep.vue
@@ -66,12 +66,21 @@ watch(
   () => emit("update:data", formData.value)
 );
 
-const validation = reactive<Record<string, boolean>>({
+const getNewValidation = () => ({
   business: false,
   workSafeBCNumber: true,
   doingBusinessAs: true,
   acronym: true,
 });
+
+const validation = reactive<Record<string, boolean>>(getNewValidation());
+
+const resetValidation = () => {
+  for (const key in validation) {
+    delete validation[key];
+  }
+  Object.assign(validation, getNewValidation());
+};
 
 const showDetailsLoading = ref<boolean>(false);
 const detailsData = ref(null);
@@ -115,7 +124,8 @@ const standingValue = (goodStanding: boolean | null | undefined) => {
 const autoCompleteResult = ref<BusinessSearchResult>();
 watch([autoCompleteResult], () => {
   // reset business validation state
-  validation.business = false;
+  resetValidation();
+
   detailsData.value = null;
   bcRegistryError.value = false;
   showOnError.value = false;
@@ -135,6 +145,10 @@ watch([autoCompleteResult], () => {
     formData.value.businessInformation.businessType = getEnumKeyByEnumValue(BusinessTypeEnum, BusinessTypeEnum.R);
 
     emit("update:data", formData.value);
+
+    if (formData.value.businessInformation.clientType === "RSP") {
+      validation.birthdate = false;
+    }
 
     const toggleErrorMessages = (
       unsupportedLegalType: boolean | null = null,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

- Requires Date of birth before enabling the button Next;
- Resets the validation for BcRegisteredClientInformationWizardStep when the selected Client name changes.

This prevents getting into a state where user can't proceed to the Next step.

Fixes [FSADT1-1508](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT1-1508)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-41-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)