### PR TITLE
fix(fe:FSADT1-1508): prevent error on Date of birth before using it

### DIFF
--- a/frontend/src/pages/staffform/BcRegisteredClientInformationWizardStep.vue
+++ b/frontend/src/pages/staffform/BcRegisteredClientInformationWizardStep.vue
@@ -523,86 +523,85 @@ onMounted(() => {
 
     </div>
 
-    <div v-if="formData.businessInformation.clientType === 'RSP'">
-      <div class="label-with-icon parent-label">
-        <div class="cds-text-input-label">
-          <span class="cds-text-input-required-label">* </span>
-          <span>Date of birth</span>
+    <template v-if="showFields || bcRegistryError || showOnError">
+      <div v-if="formData.businessInformation.clientType === 'RSP'">
+        <div class="label-with-icon parent-label">
+          <div class="cds-text-input-label">
+            <span class="cds-text-input-required-label">* </span>
+            <span>Date of birth</span>
+          </div>
+          <cds-tooltip>
+            <Information16 />
+            <cds-tooltip-content>
+              We need the applicant's birthdate to confirm their identity
+            </cds-tooltip-content>
+          </cds-tooltip>
         </div>
-        <cds-tooltip>
-          <Information16 />
-          <cds-tooltip-content>
-            We need the applicant's birthdate to confirm their identity
-          </cds-tooltip-content>
-        </cds-tooltip>
+        <date-input-component
+          id="birthdate"
+          title="Date of birth"
+          :autocomplete="['bday-year', 'bday-month', 'bday-day']"
+          v-model="formData.businessInformation.birthdate"
+          :enabled="true"
+          :validations="[
+            ...getValidations('businessInformation.birthdate'),
+            submissionValidation('businessInformation.birthdate'),
+          ]"
+          :year-validations="[...getValidations('businessInformation.birthdate.year')]"
+          @error="validation.birthdate = !$event"
+          @possibly-valid="validation.birthdate = $event"
+          required
+        />
       </div>
-      <date-input-component
-        id="birthdate"
-        title="Date of birth"
-        :autocomplete="['bday-year', 'bday-month', 'bday-day']"
-        v-model="formData.businessInformation.birthdate"
-        :enabled="true"
+
+      <text-input-component
+        id="workSafeBCNumber"
+        label="WorkSafeBC number"
+        mask="######"
+        placeholder=""
+        autocomplete="off"
+        v-model="formData.businessInformation.workSafeBcNumber"
         :validations="[
-          ...getValidations('businessInformation.birthdate'),
-          submissionValidation('businessInformation.birthdate'),
+          ...getValidations('businessInformation.workSafeBcNumber'),
+          submissionValidation(`businessInformation.workSafeBcNumber`),
         ]"
-        :year-validations="[...getValidations('businessInformation.birthdate.year')]"
-        @error="validation.birthdate = !$event"
-        @possibly-valid="validation.birthdate = $event"
-        required
+        enabled
+        @empty="validation.workSafeBCNumber = true"
+        @error="validation.workSafeBCNumber = !$event"
       />
-    </div>
 
-    <text-input-component
-      id="workSafeBCNumber"
-      v-if="showFields || bcRegistryError || showOnError"
-      label="WorkSafeBC number"
-      mask="######"
-      placeholder=""
-      autocomplete="off"
-      v-model="formData.businessInformation.workSafeBcNumber"
-      :validations="[
-        ...getValidations('businessInformation.workSafeBcNumber'),
-        submissionValidation(`businessInformation.workSafeBcNumber`),
-      ]"
-      enabled
-      @empty="validation.workSafeBCNumber = true"
-      @error="validation.workSafeBCNumber = !$event"
-    />
+      <text-input-component
+        id="doingBusinessAs"
+        v-if="formData.businessInformation.clientType !== 'RSP'"
+        label="Doing business as"
+        placeholder=""
+        autocomplete="off"
+        v-model="formData.businessInformation.doingBusinessAs"
+        :validations="[
+          ...getValidations('businessInformation.doingBusinessAs'),
+          submissionValidation(`businessInformation.doingBusinessAs`),
+        ]"
+        enabled
+        @empty="validation.doingBusinessAs = true"
+        @error="validation.doingBusinessAs = !$event"
+      />
 
-    <text-input-component
-      id="doingBusinessAs"
-      v-if="(showFields || bcRegistryError || showOnError) && formData.businessInformation.clientType !== 'RSP'"
-      label="Doing business as"
-      placeholder=""
-      autocomplete="off"
-      v-model="formData.businessInformation.doingBusinessAs"
-      :validations="[
-        ...getValidations('businessInformation.doingBusinessAs'),
-        submissionValidation(`businessInformation.doingBusinessAs`),
-      ]"
-      enabled
-      @empty="validation.doingBusinessAs = true"
-      @error="validation.doingBusinessAs = !$event"
-    />
-
-    <text-input-component
-      id="acronym"
-      v-if="showFields || bcRegistryError || showOnError"
-      label="Acronym"
-      placeholder=""
-      mask="NNNNNNNN"
-      autocomplete="off"
-      v-model="formData.businessInformation.clientAcronym"
-      :validations="[
-        ...getValidations('businessInformation.clientAcronym'),
-        submissionValidation(`businessInformation.clientAcronym`),
-      ]"
-      enabled
-      @empty="validation.acronym = true"
-      @error="validation.acronym = !$event"
-    />
-
+      <text-input-component
+        id="acronym"
+        label="Acronym"
+        placeholder=""
+        mask="NNNNNNNN"
+        autocomplete="off"
+        v-model="formData.businessInformation.clientAcronym"
+        :validations="[
+          ...getValidations('businessInformation.clientAcronym'),
+          submissionValidation(`businessInformation.clientAcronym`),
+        ]"
+        enabled
+        @empty="validation.acronym = true"
+        @error="validation.acronym = !$event"
+      />
+    </template>
   </div>
 </template>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Prevents the error message on Date of birth which appears when a Sole proprietorship that "already exists" or is "not owned by a person" gets selected, by waiting to render the Date of birth field after the client data is returned, like we do for all the other fields.
(This addresses the Note 2 on FSADT1-1508. The main fixes PR for FSADT1-1508 - #1191 - are already merged)

Fixes [FSADT1-1508](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT1-1508)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-4-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)