### PR TITLE
chore(ci): renovate matchConfidence

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,32 @@
   "description": "Presets from https://github.com/bcgov/renovate-config",
   "extends": [
     "github>bcgov/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Mend: high confidence minor and patch dependency updates",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchConfidence": [
+        "very high",
+        "high"
+      ]
+    },
+    {
+      "matchConfidence": [
+        "low"
+      ],
+      "dependencyDashboardApproval": true,
+      "commitMessagePrefix": "[LOW] "
+    },
+    {
+      "matchConfidence": [
+        "neutral"
+      ],
+      "dependencyDashboardApproval": true,
+      "commitMessagePrefix": "[NEUTRAL] "
+    }
   ]
 }


### PR DESCRIPTION
Renovate changes using matchConfidence:
- group high and very high updates together
- banish low and neutral updates to the dependency dashboard

This is safe to run, but could result in low or neutral confidence updates going unmerged.  Please make sure to occasionally check Renovate's Dependency Dashboard for this repo.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-16-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)