### PR TITLE
fix(fe:FSADT1-1521): clear the AutoComplete field when preventSelection is true

### DIFF
--- a/frontend/cypress/e2e/pages/SearchPage.cy.ts
+++ b/frontend/cypress/e2e/pages/SearchPage.cy.ts
@@ -53,15 +53,10 @@ describe("Search Page", () => {
     });
 
     it("displays autocomplete results", () => {
-      cy.get("#search-box")
-        .find("cds-combo-box-item")
-        .should("have.length", 3)
-        .should("be.visible");
-
       cy.wait("@predictiveSearch").then((interception) => {
         const data = interception.response.body;
 
-        cy.wrap(data).should("be.an", "array").and("have.length", 3);
+        cy.wrap(data).should("be.an", "array").and("have.length.greaterThan", 0);
 
         cy.get("#search-box")
           .find("cds-combo-box-item")
@@ -89,7 +84,7 @@ describe("Search Page", () => {
         cy.wait("@predictiveSearch").then((interception) => {
           const data = interception.response.body;
 
-          cy.wrap(data).should("be.an", "array").and("have.length.greaterThan", 3);
+          cy.wrap(data).should("be.an", "array").and("have.length.greaterThan", 0);
 
           cy.get("#search-box")
             .find("cds-combo-box-item")
@@ -102,11 +97,11 @@ describe("Search Page", () => {
     });
 
     describe("and user clicks a result", () => {
-      const clientNumber = "00001297";
+      const clientNumber = "00054076";
       beforeEach(() => {
         cy.get("#search-box")
           .find("cds-combo-box-item")
-          .should("have.length", 3)
+          .should("have.length.greaterThan", 0)
           .should("be.visible");
 
         cy.get("#search-box").find(`cds-combo-box-item[data-value^="${clientNumber}"]`).click();

--- a/frontend/src/components/forms/AutoCompleteInputComponent.vue
+++ b/frontend/src/components/forms/AutoCompleteInputComponent.vue
@@ -192,10 +192,12 @@ const selectAutocompleteItem = (event: any) => {
 };
 
 const preSelectAutocompleteItem = (event: any) => {
-  const newValue = event?.detail?.item?.getAttribute("data-id");
-  emit("click:option", newValue);
-  if (props.preventSelection) {
-    event?.preventDefault();
+  if (event?.detail?.item) {
+    const newValue = event?.detail?.item?.getAttribute("data-id");
+    emit("click:option", newValue);
+    if (props.preventSelection) {
+      event?.preventDefault();
+    }
   }
 };
 

--- a/frontend/tests/unittests/components/forms/AutoCompleteInputComponent.spec.ts
+++ b/frontend/tests/unittests/components/forms/AutoCompleteInputComponent.spec.ts
@@ -13,10 +13,19 @@ describe("Auto Complete Input Component", () => {
     { code: "TC", name: "TAMCADA" },
     { code: "TD", name: "TADANARA" },
   ];
+
   const eventSelectContent = (value: string) => {
     return {
       detail: {
         item: { "data-id": value, getAttribute: (key: string) => value },
+      },
+    };
+  };
+
+  const eventClearContent = () => {
+    return {
+      detail: {
+        item: undefined,
       },
     };
   };
@@ -309,29 +318,46 @@ describe("Auto Complete Input Component", () => {
     expect(wrapper.emitted("update:selected-value")![0][0]).toEqual(selectedContent);
   });
 
-  it('emits the "click:option" event with the code of the clicked option and prevents selecting it', async () => {
-    const wrapper = mount(AutoCompleteInputComponent, {
-      props: {
-        id,
-        modelValue: "",
-        contents,
-        validations: [],
-        label: id,
-        tip: "",
-        preventSelection: true,
-      },
+  describe("when preventSelection is true", () => {
+    let wrapper: VueWrapper;
+    beforeEach(() => {
+      wrapper = mount(AutoCompleteInputComponent, {
+        props: {
+          id,
+          modelValue: "",
+          contents,
+          validations: [],
+          label: id,
+          tip: "",
+          preventSelection: true,
+        },
+      });
     });
 
-    await wrapper.setProps({ modelValue: "T" });
-    await wrapper.find(`#${id}`).trigger("input");
+    it('emits the "click:option" event with the code of the clicked option and prevents selecting it', async () => {
+      await wrapper.setProps({ modelValue: "T" });
+      await wrapper.find(`#${id}`).trigger("input");
 
-    const code = "TB";
-    await wrapper.find(`#${id}`).trigger("cds-combo-box-beingselected", eventSelectContent(code));
+      const code = "TB";
+      await wrapper.find(`#${id}`).trigger("cds-combo-box-beingselected", eventSelectContent(code));
 
-    expect(wrapper.emitted("click:option")).toBeTruthy();
-    expect(wrapper.emitted("click:option")![0][0]).toEqual(code);
+      expect(wrapper.emitted("click:option")).toBeTruthy();
+      expect(wrapper.emitted("click:option")![0][0]).toEqual(code);
 
-    expect(wrapper.emitted("update:selected-value")).toBeFalsy();
+      expect(wrapper.emitted("update:selected-value")).toBeFalsy();
+    });
+
+    it("doesn't prevent the clearing action", async () => {
+      await wrapper.setProps({ modelValue: "T" });
+      await wrapper.find(`#${id}`).trigger("input");
+
+      // User initiated event to clear the value
+      await wrapper.find(`#${id}`).trigger("cds-combo-box-beingselected", eventClearContent());
+
+      // Clears the value
+      expect(wrapper.emitted("update:selected-value")).toBeTruthy();
+      expect(wrapper.emitted("update:selected-value")![0][0]).toEqual(undefined);
+    });
   });
 
   it('emits the "update:selected-value" event when an option from the list is clicked', async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This is a fix for #1223.
Stops preventing the action to clear the input value when preventSelection is true.
And also fixes tests that broke after updates on feat/client3.

Fixes [FSADT1-1521](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT1-1521)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-30-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)