### PR TITLE
chore(ci): route update

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -210,7 +210,7 @@ jobs:
             -p COGNITO_DOMAIN=${{ secrets.COGNITO_DOMAIN }}
             -p COGNITO_ENVIRONMENT=TEST
             -p LANDING_URL='${{ secrets.COGNITO_LOGOUT_URI }}'
-            -p FRONTEND_URL=${{ env.URL }}
+            -p URL=${{ env.URL }}
 
   prod-init:
     name: PROD Init

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -214,7 +214,6 @@ jobs:
             -p COGNITO_DOMAIN=${{ secrets.COGNITO_DOMAIN }}
             -p COGNITO_ENVIRONMENT=TEST
             -p LANDING_URL='${{ secrets.COGNITO_LOGOUT_URI }}'
-            -p FRONTEND_URL=${{ env.URL }}
 
   prod-init:
     name: PROD Init
@@ -401,7 +400,6 @@ jobs:
             -p COGNITO_DOMAIN=${{ secrets.COGNITO_DOMAIN }}
             -p COGNITO_ENVIRONMENT=PROD
             -p LANDING_URL='${{ secrets.COGNITO_LOGOUT_URI }}'
-            -p FRONTEND_URL=${{ env.URL }}
 
   images-prod:
     name: Promote images to PROD

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -29,6 +29,7 @@ jobs:
     name: TEST Init
     env:
       ZONE: test
+      URL: forestclient-tst.nrs.gov.bc.ca
     environment: test
     runs-on: ubuntu-24.04
     steps:
@@ -67,6 +68,7 @@ jobs:
     needs: [test-init, vars]
     env:
       TAG: ${{ needs.vars.outputs.pr }}
+      URL: forestclient-tst.nrs.gov.bc.ca
       ZONE: test
     environment: test
     runs-on: ubuntu-24.04
@@ -166,6 +168,7 @@ jobs:
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
             -p COGNITO_REGION=ca-central-1
+            -p FRONTEND_URL=${{ env.URL }}
 
       - name: Dev data replacement
         uses: bcgov/action-deployer-openshift@v3.2.0
@@ -204,18 +207,20 @@ jobs:
             -p TAG=${{ env.TAG }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}
+            -p URL=${{ env.URL }}
             -p COGNITO_REGION=${{ secrets.COGNITO_REGION }}
             -p COGNITO_CLIENT_ID=${{ secrets.COGNITO_CLIENT_ID }}
             -p COGNITO_USER_POOL=${{ secrets.COGNITO_USER_POOL }}
             -p COGNITO_DOMAIN=${{ secrets.COGNITO_DOMAIN }}
             -p COGNITO_ENVIRONMENT=TEST
             -p LANDING_URL='${{ secrets.COGNITO_LOGOUT_URI }}'
-            -p URL=${{ env.URL }}
+            -p FRONTEND_URL=${{ env.URL }}
 
   prod-init:
     name: PROD Init
     needs: [test-deploy]
     env:
+      URL: forestclient.nrs.gov.bc.ca
       ZONE: prod
     environment: prod
     runs-on: ubuntu-24.04
@@ -255,6 +260,7 @@ jobs:
     needs: [prod-init, vars]
     env:
       TAG: ${{ needs.vars.outputs.pr }}
+      URL: forestclient.nrs.gov.bc.ca
       ZONE: prod
     environment: prod
     runs-on: ubuntu-24.04
@@ -360,6 +366,7 @@ jobs:
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
             -p COGNITO_REGION=ca-central-1
+            -p FRONTEND_URL=${{ env.URL }}
 
       - name: Deploy Frontend ConfigMap
         uses: bcgov/action-deployer-openshift@v3.2.0
@@ -387,12 +394,14 @@ jobs:
             -p TAG=${{ env.TAG }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}
+            -p URL=${{ env.URL }}
             -p COGNITO_REGION=${{ secrets.COGNITO_REGION }}
             -p COGNITO_CLIENT_ID=${{ secrets.COGNITO_CLIENT_ID }}
             -p COGNITO_USER_POOL=${{ secrets.COGNITO_USER_POOL }}
             -p COGNITO_DOMAIN=${{ secrets.COGNITO_DOMAIN }}
             -p COGNITO_ENVIRONMENT=PROD
             -p LANDING_URL='${{ secrets.COGNITO_LOGOUT_URI }}'
+            -p FRONTEND_URL=${{ env.URL }}
 
   images-prod:
     name: Promote images to PROD

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -29,7 +29,6 @@ jobs:
     name: TEST Init
     env:
       ZONE: test
-      URL: forestclient-tst.nrs.gov.bc.ca
     environment: test
     runs-on: ubuntu-24.04
     steps:
@@ -68,7 +67,6 @@ jobs:
     needs: [test-init, vars]
     env:
       TAG: ${{ needs.vars.outputs.pr }}
-      URL: forestclient-tst.nrs.gov.bc.ca
       ZONE: test
     environment: test
     runs-on: ubuntu-24.04
@@ -168,7 +166,6 @@ jobs:
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
             -p COGNITO_REGION=ca-central-1
-            -p FRONTEND_URL=${{ env.URL }}
 
       - name: Dev data replacement
         uses: bcgov/action-deployer-openshift@v3.2.0
@@ -207,7 +204,6 @@ jobs:
             -p TAG=${{ env.TAG }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}
-            -p URL=${{ env.URL }}
             -p COGNITO_REGION=${{ secrets.COGNITO_REGION }}
             -p COGNITO_CLIENT_ID=${{ secrets.COGNITO_CLIENT_ID }}
             -p COGNITO_USER_POOL=${{ secrets.COGNITO_USER_POOL }}
@@ -220,7 +216,6 @@ jobs:
     name: PROD Init
     needs: [test-deploy]
     env:
-      URL: forestclient.nrs.gov.bc.ca
       ZONE: prod
     environment: prod
     runs-on: ubuntu-24.04
@@ -260,7 +255,6 @@ jobs:
     needs: [prod-init, vars]
     env:
       TAG: ${{ needs.vars.outputs.pr }}
-      URL: forestclient.nrs.gov.bc.ca
       ZONE: prod
     environment: prod
     runs-on: ubuntu-24.04
@@ -366,7 +360,6 @@ jobs:
             -p CHES_API_URL='https://ches.api.gov.bc.ca/api/v1'
             -p BCREGISTRY_URI='https://bcregistry-prod.apigee.net'
             -p COGNITO_REGION=ca-central-1
-            -p FRONTEND_URL=${{ env.URL }}
 
       - name: Deploy Frontend ConfigMap
         uses: bcgov/action-deployer-openshift@v3.2.0
@@ -394,14 +387,12 @@ jobs:
             -p TAG=${{ env.TAG }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p VITE_NODE_ENV=openshift-${{ env.ZONE }}
-            -p URL=${{ env.URL }}
             -p COGNITO_REGION=${{ secrets.COGNITO_REGION }}
             -p COGNITO_CLIENT_ID=${{ secrets.COGNITO_CLIENT_ID }}
             -p COGNITO_USER_POOL=${{ secrets.COGNITO_USER_POOL }}
             -p COGNITO_DOMAIN=${{ secrets.COGNITO_DOMAIN }}
             -p COGNITO_ENVIRONMENT=PROD
             -p LANDING_URL='${{ secrets.COGNITO_LOGOUT_URI }}'
-            -p FRONTEND_URL=${{ env.URL }}
 
   images-prod:
     name: Promote images to PROD

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -214,7 +214,6 @@ jobs:
             -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
             -p VITE_NODE_ENV=openshift-dev
-            -p URL=${{ needs.vars.outputs.url }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p COGNITO_REGION=${{ secrets.COGNITO_REGION }}
             -p COGNITO_CLIENT_ID=${{ secrets.COGNITO_CLIENT_ID }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -20,6 +20,7 @@ jobs:
         id: calculate
         run: |
           echo "url=${{ github.event.repository.name }}-$((${{ github.event.number }} % 50))-frontend.apps.silver.devops.gov.bc.ca" >> $GITHUB_OUTPUT
+          echo "url=${{ github.event.repository.name }}-$((${{ github.event.number }} % 50))-frontend.apps.silver.devops.gov.bc.ca"
 
   builds:
     name: Builds

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -222,7 +222,6 @@ jobs:
             -p COGNITO_DOMAIN=${{ secrets.COGNITO_DOMAIN }}
             -p COGNITO_ENVIRONMENT=DEV
             -p LANDING_URL=${{ needs.vars.outputs.url }}
-            -p FRONTEND_URL=${{ needs.vars.outputs.url }}
 
   tests:
     name: Tests

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -214,6 +214,7 @@ jobs:
             -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
             -p VITE_NODE_ENV=openshift-dev
+            -p URL=${{ needs.vars.outputs.url }}
             -p GREEN_DOMAIN=${{ secrets.GREEN_DOMAIN }}
             -p COGNITO_REGION=${{ secrets.COGNITO_REGION }}
             -p COGNITO_CLIENT_ID=${{ secrets.COGNITO_CLIENT_ID }}
@@ -221,7 +222,7 @@ jobs:
             -p COGNITO_DOMAIN=${{ secrets.COGNITO_DOMAIN }}
             -p COGNITO_ENVIRONMENT=DEV
             -p LANDING_URL=${{ needs.vars.outputs.url }}
-            -p URL=${{ needs.vars.outputs.url }}
+            -p FRONTEND_URL=${{ needs.vars.outputs.url }}
 
   tests:
     name: Tests

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -221,7 +221,7 @@ jobs:
             -p COGNITO_DOMAIN=${{ secrets.COGNITO_DOMAIN }}
             -p COGNITO_ENVIRONMENT=DEV
             -p LANDING_URL=${{ needs.vars.outputs.url }}
-            -p FRONTEND_URL=${{ needs.vars.outputs.url }}
+            -p URL=${{ needs.vars.outputs.url }}
 
   tests:
     name: Tests

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -221,24 +221,3 @@ objects:
           targetPort: 8080
       selector:
         deployment: ${NAME}-${ZONE}-${COMPONENT}
-  - kind: Route
-    apiVersion: route.openshift.io/v1
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}
-      annotations:
-        haproxy.router.openshift.io/rate-limit-connections: "true"
-        haproxy.router.openshift.io/rate-limit-connections.rate-http: "150"
-        haproxy.router.openshift.io/rate-limit-connections.rate-tcp: "75"
-    spec:
-      host: ${NAME}-${ZONE}-${COMPONENT}.${DOMAIN}
-      port:
-        targetPort: 8080-tcp
-      to:
-        kind: Service
-        name: ${NAME}-${ZONE}-${COMPONENT}
-        weight: 100
-      tls:
-        termination: edge
-        insecureEdgeTerminationPolicy: Redirect

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -207,8 +207,12 @@ objects:
       labels:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
+      annotations:
+        haproxy.router.openshift.io/rate-limit-connections: "true"
+        haproxy.router.openshift.io/rate-limit-connections.rate-http: "150"
+        haproxy.router.openshift.io/rate-limit-connections.rate-tcp: "75"
     spec:
-      host: ${URL}
+      host: ${NAME}-${ZONE}-${COMPONENT}.${DOMAIN}
       port:
         targetPort: 3000-tcp
       to:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -209,7 +209,7 @@ objects:
         haproxy.router.openshift.io/rate-limit-connections.rate-http: "150"
         haproxy.router.openshift.io/rate-limit-connections.rate-tcp: "75"
     spec:
-      host: ${NAME}-${ZONE}-${COMPONENT}.${DOMAIN}
+      host: ${URL}
       port:
         targetPort: 3000-tcp
       to:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -73,9 +73,6 @@ parameters:
     required: true  
   - name: LANDING_URL
     required: true
-  - name: FRONTEND_URL
-    description: Frontend URL
-    required: true
   - name: RANDOM_EXPRESSION
     description: Random expression to make sure deployments update
     from: "[a-zA-Z0-9]{32}"
@@ -143,7 +140,7 @@ objects:
                 - name: BACKEND_URL
                   value: https://${NAME}-${ZONE}-backend.${DOMAIN}
                 - name: FRONTEND_URL
-                  value: https://${FRONTEND_URL}
+                  value: https://${URL}
                 - name: COGNITO_REGION
                   value: ${COGNITO_REGION}
                 - name: COGNITO_DOMAIN


### PR DESCRIPTION
Split the default route off from the vanity URL so that workflows and deployments can happen without overwriting TEST and PROD routes with certificates.

Remove backend route, which isn't in use.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-34-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)