### PR TITLE
chore(ci): bcgov/action-oc-runner

### DIFF
--- a/.github/workflows/.tools-cleanup.yml
+++ b/.github/workflows/.tools-cleanup.yml
@@ -16,7 +16,6 @@ jobs:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
           oc_server: ${{ secrets.oc_server }}
-          triggers: ${{ inputs.triggers }}
           commands: |
             # This removes a new pluggable database, user and service for the PR
             for i in {1..5}; do

--- a/.github/workflows/.tools-cleanup.yml
+++ b/.github/workflows/.tools-cleanup.yml
@@ -9,29 +9,28 @@ jobs:
     environment: tools
     runs-on: ubuntu-24.04
     steps:
-      - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:        
-          oc: "4.13"
-          
       - name: Remove the PR database
         continue-on-error: true
-        run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-          oc project ${{ secrets.OC_NAMESPACE }} # Safeguard!
-          # This removes a new pluggable database, user and service for the PR
-          for i in {1..5}; do
-            POD_NAME=$(oc get pods -l app=nr-forest-client-tools -l deployment=nr-forest-client-tools-legacydb -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-            if [ -n "$POD_NAME" ]; then
-              echo "Pod found: $POD_NAME"
-              oc exec $POD_NAME -- /opt/oracle/removeDatabase "THE" "PR_${{ github.event.number }}"
-              break
-            else
-              echo "Pod not found, retrying in 10 seconds... ($i/5)"
-              sleep 10
-            fi
-          done
+        uses: bcgov/action-oc-runner@v1.0.0
+        with:
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ secrets.oc_server }}
+          triggers: ${{ inputs.triggers }}
+          commands: |
+            # This removes a new pluggable database, user and service for the PR
+            for i in {1..5}; do
+              POD_NAME=$(oc get pods -l app=nr-forest-client-tools -l deployment=nr-forest-client-tools-legacydb -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+              if [ -n "$POD_NAME" ]; then
+                echo "Pod found: $POD_NAME"
+                oc exec $POD_NAME -- /opt/oracle/removeDatabase "THE" "PR_${{ github.event.number }}"
+                break
+              else
+                echo "Pod not found, retrying in 10 seconds... ($i/5)"
+                sleep 10
+              fi
+            done
 
-          if [ -z "$POD_NAME" ]; then
-            echo "Failed to find the pod after 5 attempts."
-          fi
+            if [ -z "$POD_NAME" ]; then
+              echo "Failed to find the pod after 5 attempts."
+            fi

--- a/.github/workflows/.tools-deploy.yml
+++ b/.github/workflows/.tools-deploy.yml
@@ -38,7 +38,6 @@ jobs:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
           oc_server: ${{ secrets.oc_server }}
-          triggers: ${{ inputs.triggers }}
           commands: |
             oc scale deployment/nr-forest-client-${{ github.event.number }}-legacy --replicas=0 -n ${{ secrets.OC_NAMESPACE }}
             undesired_replicas=0  
@@ -95,7 +94,6 @@ jobs:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
           oc_server: ${{ secrets.oc_server }}
-          triggers: ${{ inputs.triggers }}
           commands: |
             # This creates a new pluggable database for the PR
             for i in {1..5}; do
@@ -121,7 +119,6 @@ jobs:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
           oc_server: ${{ secrets.oc_server }}
-          triggers: ${{ inputs.triggers }}
           commands: |
             # This creates a new pluggable database for the PR
             for i in {1..5}; do
@@ -147,7 +144,6 @@ jobs:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
           oc_server: ${{ secrets.oc_server }}
-          triggers: ${{ inputs.triggers }}
           commands: |
             BRANCH_NAME="${{ github.head_ref }}"
             ESCAPED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/&]/\\&/g')
@@ -167,6 +163,5 @@ jobs:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
           oc_server: ${{ secrets.oc_server }}
-          triggers: ${{ inputs.triggers }}
           commands: |
             oc scale deployment/nr-forest-client-${{ github.event.number }}-legacy --replicas=1

--- a/.github/workflows/.tools-deploy.yml
+++ b/.github/workflows/.tools-deploy.yml
@@ -31,30 +31,29 @@ jobs:
     environment: dev
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:        
-          oc: "4.13"
       - name: Scale down legacy
         continue-on-error: true
-        run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-          oc project ${{ secrets.OC_NAMESPACE }} # Safeguard!
-          oc scale deployment/nr-forest-client-${{ github.event.number }}-legacy --replicas=0 -n ${{ secrets.OC_NAMESPACE }}
-          undesired_replicas=0  
+        uses: bcgov/action-oc-runner@v1.0.0
+        with:
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ secrets.oc_server }}
+          triggers: ${{ inputs.triggers }}
+          commands: |
+            oc scale deployment/nr-forest-client-${{ github.event.number }}-legacy --replicas=0 -n ${{ secrets.OC_NAMESPACE }}
+            undesired_replicas=0  
 
-          while true; do
-            available_replicas=$(oc get deployment/nr-forest-client-${{ github.event.number }}-legacy -n ${{ secrets.OC_NAMESPACE }} -o jsonpath='{.status.availableReplicas}')
-            
-            if [[ "$available_replicas" -ge "$undesired_replicas" ]]; then
-              echo "DeploymentConfig ${{ secrets.OC_NAMESPACE }}-${{ github.event.number }}-legacy is now available with $available_replicas replicas."
-              break
-            fi
-            
-            echo "Waiting... ($available_replicas pods available)"
-            sleep 5
-          done
+            while true; do
+              available_replicas=$(oc get deployment/nr-forest-client-${{ github.event.number }}-legacy -n ${{ secrets.OC_NAMESPACE }} -o jsonpath='{.status.availableReplicas}')
+              
+              if [[ "$available_replicas" -ge "$undesired_replicas" ]]; then
+                echo "DeploymentConfig ${{ secrets.OC_NAMESPACE }}-${{ github.event.number }}-legacy is now available with $available_replicas replicas."
+                break
+              fi
+              
+              echo "Waiting... ($available_replicas pods available)"
+              sleep 5
+            done
 
   deploy-oracle:
     name: Deploy Oracle Database
@@ -62,8 +61,6 @@ jobs:
     environment: tools
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-
       - name: Initializing Deployment
         uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -91,65 +88,70 @@ jobs:
     environment: tools
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:        
-          oc: "4.13"
-
       - name: Create the PR database
         continue-on-error: true
-        run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-          oc project ${{ secrets.OC_NAMESPACE }} # Safeguard!
-          # This creates a new pluggable database for the PR
-          for i in {1..5}; do
-            POD_NAME=$(oc get pods -l app=nr-forest-client-tools  -l deployment=nr-forest-client-tools-legacydb -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-            if [ -n "$POD_NAME" ]; then
-              echo "Pod found: $POD_NAME"
-              oc exec $POD_NAME -- /opt/oracle/createDatabase PR_${{ github.event.number }}
-              break
-            else
-              echo "Pod not found, retrying in 10 seconds... ($i/5)"
-              sleep 10
-            fi
-          done
+        uses: bcgov/action-oc-runner@v1.0.0
+        with:
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ secrets.oc_server }}
+          triggers: ${{ inputs.triggers }}
+          commands: |
+            # This creates a new pluggable database for the PR
+            for i in {1..5}; do
+              POD_NAME=$(oc get pods -l app=nr-forest-client-tools  -l deployment=nr-forest-client-tools-legacydb -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+              if [ -n "$POD_NAME" ]; then
+                echo "Pod found: $POD_NAME"
+                oc exec $POD_NAME -- /opt/oracle/createDatabase PR_${{ github.event.number }}
+                break
+              else
+                echo "Pod not found, retrying in 10 seconds... ($i/5)"
+                sleep 10
+              fi
+            done
 
-          if [ -z "$POD_NAME" ]; then
-            echo "Failed to find the pod after 5 attempts."
-          fi
+            if [ -z "$POD_NAME" ]; then
+              echo "Failed to find the pod after 5 attempts."
+            fi
 
       - name: Create the PR user
         continue-on-error: true
-        run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-          oc project ${{ secrets.OC_NAMESPACE }} # Safeguard!
-          # This creates a new pluggable database for the PR
-          for i in {1..5}; do
-            POD_NAME=$(oc get pods -l app=nr-forest-client-tools -l deployment=nr-forest-client-tools-legacydb -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-            if [ -n "$POD_NAME" ]; then
-              echo "Pod found: $POD_NAME"
-              oc exec $POD_NAME -- /opt/oracle/createAppUser "THE" "${{ secrets.ORACLEDB_PASSWORD_W }}_${{ github.event.number }}" "PR_${{ github.event.number }}"
-              break
-            else
-              echo "Pod not found, retrying in 10 seconds... ($i/5)"
-              sleep 10
-            fi
-          done
+        uses: bcgov/action-oc-runner@v1.0.0
+        with:
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ secrets.oc_server }}
+          triggers: ${{ inputs.triggers }}
+          commands: |
+            # This creates a new pluggable database for the PR
+            for i in {1..5}; do
+              POD_NAME=$(oc get pods -l app=nr-forest-client-tools -l deployment=nr-forest-client-tools-legacydb -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+              if [ -n "$POD_NAME" ]; then
+                echo "Pod found: $POD_NAME"
+                oc exec $POD_NAME -- /opt/oracle/createAppUser "THE" "${{ secrets.ORACLEDB_PASSWORD_W }}_${{ github.event.number }}" "PR_${{ github.event.number }}"
+                break
+              else
+                echo "Pod not found, retrying in 10 seconds... ($i/5)"
+                sleep 10
+              fi
+            done
 
-          if [ -z "$POD_NAME" ]; then
-            echo "Failed to find the pod after 5 attempts."
-          fi
+            if [ -z "$POD_NAME" ]; then
+              echo "Failed to find the pod after 5 attempts."
+            fi
 
       - name: Migrate the PR database
         continue-on-error: true
-        run: |
-          BRANCH_NAME="${{ github.head_ref }}"
-          # Escape slashes and other special characters
-          ESCAPED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/&]/\\&/g')
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-          oc project ${{ secrets.OC_NAMESPACE }} # Safeguard!
-          oc create job --from=cronjob/nr-forest-client-tools-migratedb migrate-pr${{ github.event.number }}-${{ github.run_attempt }}-$(date +%s) --dry-run=client -o yaml | sed "s/value: main/value: ${ESCAPED_BRANCH_NAME}/" | sed "s/value: \"0\"/value: \"${{ github.event.number }}\"/" | oc apply -f -
+        uses: bcgov/action-oc-runner@v1.0.0
+        with:
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ secrets.oc_server }}
+          triggers: ${{ inputs.triggers }}
+          commands: |
+            BRANCH_NAME="${{ github.head_ref }}"
+            ESCAPED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/&]/\\&/g')
+            oc create job --from=cronjob/nr-forest-client-tools-migratedb migrate-pr${{ github.event.number }}-${{ github.run_attempt }}-$(date +%s) --dry-run=client -o yaml | sed "s/value: main/value: ${ESCAPED_BRANCH_NAME}/" | sed "s/value: \"0\"/value: \"${{ github.event.number }}\"/" | oc apply -f -
   
   scale-up-legacy:
     name: Scale up legacy
@@ -158,14 +160,13 @@ jobs:
     if: always()    
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:        
-          oc: "4.13"
       - name: Start the Legacy Service
         continue-on-error: true
-        run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-          oc project ${{ secrets.OC_NAMESPACE }} # Safeguard!
-          oc scale deployment/nr-forest-client-${{ github.event.number }}-legacy --replicas=1
+        uses: bcgov/action-oc-runner@v1.0.0
+        with:
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ secrets.oc_server }}
+          triggers: ${{ inputs.triggers }}
+          commands: |
+            oc scale deployment/nr-forest-client-${{ github.event.number }}-legacy --replicas=1

--- a/.github/workflows/.tools-deploy.yml
+++ b/.github/workflows/.tools-deploy.yml
@@ -22,8 +22,6 @@ jobs:
           tag: ${{ github.event.number }}
           tag_fallback: latest
           triggers: ('legacydb/')
-          build_args: |
-            APP_VERSION=${{ github.event.number }}
 
   pre-tools:
     name: Pre Deploy Tools

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -90,11 +90,12 @@ jobs:
 
       - name: Backup database before update
         continue-on-error: true
-        run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-          oc project ${{ secrets.OC_NAMESPACE }}
-          # Run a backup before deploying a new version
-          oc create job --from=cronjob/${{ github.event.repository.name }}-${{ env.ZONE }}-database-backup ${{ github.event.repository.name }}-${{ env.ZONE }}-database-backup-$(date +%Y%m%d%H%M%S)
+        uses: bcgov/action-oc-runner@v1.0.0
+        with:
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ secrets.oc_server }}
+          cronjob: ${{ github.event.repository.name }}-${{ env.ZONE }}-database-backup
 
       - name: Deploy Database
         uses: bcgov/action-deployer-openshift@v4.0.0
@@ -275,20 +276,15 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }}
             -p TAG=${{ env.TAG }}
-            
-      - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:        
-          oc: "4.13"
 
       - name: Backup database before update
         continue-on-error: true
-        run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-          oc project ${{ secrets.OC_NAMESPACE }} # Safeguard!
-
-          # Run a backup before deploying a new version
-          oc create job --from=cronjob/${{ github.event.repository.name }}-${{ env.ZONE }}-database-backup ${{ github.event.repository.name }}-${{ env.ZONE }}-database-backup-$(date +%Y%m%d%H%M%S)
+        uses: bcgov/action-oc-runner@v1.0.0
+        with:
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ secrets.oc_server }}
+          cronjob: ${{ github.event.repository.name }}-${{ env.ZONE }}-database-backup
 
       - name: Deploy Database
         uses: bcgov/action-deployer-openshift@v4.0.0

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -90,19 +90,16 @@ jobs:
           parameters:
             -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
-      - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:        
-          oc: "4.13"
+
       - name: Backup database before update
         continue-on-error: true
-        run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-          oc project ${{ secrets.OC_NAMESPACE }} # Safeguard!
-
-          # Run a backup before deploying a new version
-          oc create job --from=cronjob/${{ github.event.repository.name }}-${{ github.event.number }}-database-backup \
-            ${{ github.event.repository.name }}-${{ github.event.number }}-database-backup-$(date +%Y%m%d%H%M%S)
+        uses: bcgov/action-oc-runner@v1.0.0
+        with:
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ secrets.oc_server }}
+          triggers: ${{ inputs.triggers }}
+          cronjob: ${{ github.event.repository.name }}-${{ github.event.number }}-database-backup
 
       - name: Deploy Database
         uses: bcgov/action-deployer-openshift@v4.0.0

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -98,7 +98,6 @@ jobs:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
           oc_server: ${{ secrets.oc_server }}
-          triggers: ${{ inputs.triggers }}
           cronjob: ${{ github.event.repository.name }}-${{ github.event.number }}-database-backup
 
       - name: Deploy Database

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -38,8 +38,6 @@ jobs:
           tag: ${{ github.event.number }}
           tag_fallback: latest
           triggers: ('${{ matrix.package }}/')
-          build_args: |
-            APP_VERSION=${{ github.event.number }}
 
   deploy:
     name: Deploy Application


### PR DESCRIPTION
Use bcgov/action-oc-runner instead of redhat-actions/openshift-tools-installer, which is infrequently maintained and has slowdown issues.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-15-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)