### PR TITLE
chore(ci): deprecate openshift resource limits

### DIFF
--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -35,12 +35,8 @@ parameters:
     required: true
   - name: CPU_REQUEST
     value: 75m
-  - name: CPU_LIMIT
-    value: 200m
   - name: MEMORY_REQUEST
     value: 200Mi
-  - name: MEMORY_LIMIT
-    value: 256Mi
   - name: BCREGISTRY_URI
     description: Bc Registry API address
     required: true
@@ -191,9 +187,6 @@ objects:
                 - containerPort: 8080
                   protocol: TCP
               resources:
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -35,11 +35,7 @@ parameters:
     value: ghcr.io
   - name: CPU_REQUEST
     value: 10m
-  - name: CPU_LIMIT
-    value: 25m
   - name: MEMORY_REQUEST
-    value: 50Mi
-  - name: MEMORY_LIMIT
     value: 50Mi
   - name: VITE_KEYCLOAK_URL
     value: https://loginproxy.gov.bc.ca/auth
@@ -123,9 +119,6 @@ objects:
                 - containerPort: 3000
                   protocol: TCP
               resources:
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}

--- a/legacy/openshift.deploy.yml
+++ b/legacy/openshift.deploy.yml
@@ -34,12 +34,8 @@ parameters:
     value: "1543"
   - name: CPU_REQUEST
     value: 75m
-  - name: CPU_LIMIT
-    value: 200m
   - name: MEMORY_REQUEST
     value: 200Mi
-  - name: MEMORY_LIMIT
-    value: 256Mi
   - name: CERT_PVC_SIZE
     description: The amount of storage the cert PVC should have
     value: 25Mi
@@ -110,9 +106,6 @@ objects:
                 - name: ${NAME}-${ZONE}-certs
                   mountPath: /cert
               resources:
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
@@ -168,9 +161,6 @@ objects:
                 - containerPort: 9000
                   protocol: TCP
               resources:
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}

--- a/legacydb/openshift.deploy.yml
+++ b/legacydb/openshift.deploy.yml
@@ -30,12 +30,8 @@ parameters:
     required: true
   - name: CPU_REQUEST
     value: 125m
-  - name: CPU_LIMIT
-    value: 500m
   - name: MEMORY_REQUEST
     value: 3.5Gi
-  - name: MEMORY_LIMIT
-    value: 4Gi
   - name: RANDOM_EXPRESSION
     description: Random expression to make sure deployments update
     from: "[a-zA-Z0-9]{32}"
@@ -78,9 +74,6 @@ objects:
             - name: ${NAME}
               image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}
               resources:
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}

--- a/processor/openshift.deploy.yml
+++ b/processor/openshift.deploy.yml
@@ -29,12 +29,8 @@ parameters:
     value: ghcr.io
   - name: CPU_REQUEST
     value: 75m
-  - name: CPU_LIMIT
-    value: 200m
   - name: MEMORY_REQUEST
     value: 300Mi
-  - name: MEMORY_LIMIT
-    value: 400Mi
   - name: BCREGISTRY_URI
     description: Bc Registry API address
     required: true
@@ -43,7 +39,6 @@ parameters:
     from: "[a-zA-Z0-9]{32}"
     generate: expression
 objects:
-
   - kind: Deployment
     apiVersion: apps/v1
     metadata:
@@ -125,9 +120,6 @@ objects:
                 - containerPort: 3000
                   protocol: TCP
               resources:
-                limits:
-                  cpu: ${CPU_LIMIT}
-                  memory: ${MEMORY_LIMIT}
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}


### PR DESCRIPTION
Removed by OCIO platform team.  We're just following their lead.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-41-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)