### PR TITLE
chore(ci): scale down legacydb before removing PR db 

### DIFF
--- a/.github/workflows/.tools-cleanup.yml
+++ b/.github/workflows/.tools-cleanup.yml
@@ -56,3 +56,9 @@ jobs:
             if [ -z "$POD_NAME" ]; then
               echo "Failed to find the pod after 5 attempts."
             fi
+
+      - name: Remove completed pods and jobs (cronjobs)
+        run: |
+          oc delete po --field-selector=status.phase==Succeeded
+          oc get jobs --field-selector status.successful=1
+    

--- a/.github/workflows/.tools-cleanup.yml
+++ b/.github/workflows/.tools-cleanup.yml
@@ -55,5 +55,5 @@ jobs:
       - name: Remove completed pods and jobs (cronjobs)
         run: |
           oc delete po --field-selector=status.phase==Succeeded
-          oc get jobs --field-selector status.successful=1
+          oc delete jobs --field-selector status.successful=1
     

--- a/.github/workflows/.tools-cleanup.yml
+++ b/.github/workflows/.tools-cleanup.yml
@@ -34,28 +34,23 @@ jobs:
 
       - name: Remove the PR database
         continue-on-error: true
-        uses: bcgov/action-oc-runner@v1.0.0
-        with:
-          oc_namespace: ${{ secrets.oc_namespace }}
-          oc_token: ${{ secrets.oc_token }}
-          oc_server: ${{ secrets.oc_server }}
-          commands: |
-            # This removes a new pluggable database, user and service for the PR
-            for i in {1..5}; do
-              POD_NAME=$(oc get pods -l app=nr-forest-client-tools -l deployment=nr-forest-client-tools-legacydb -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-              if [ -n "$POD_NAME" ]; then
-                echo "Pod found: $POD_NAME"
-                oc exec $POD_NAME -- /opt/oracle/removeDatabase "THE" "PR_${{ github.event.number }}"
-                break
-              else
-                echo "Pod not found, retrying in 10 seconds... ($i/5)"
-                sleep 10
-              fi
-            done
-
-            if [ -z "$POD_NAME" ]; then
-              echo "Failed to find the pod after 5 attempts."
+        run: |
+          # This removes a new pluggable database, user and service for the PR
+          for i in {1..5}; do
+            POD_NAME=$(oc get pods -l app=nr-forest-client-tools -l deployment=nr-forest-client-tools-legacydb -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+            if [ -n "$POD_NAME" ]; then
+              echo "Pod found: $POD_NAME"
+              oc exec $POD_NAME -- /opt/oracle/removeDatabase "THE" "PR_${{ github.event.number }}"
+              break
+            else
+              echo "Pod not found, retrying in 10 seconds... ($i/5)"
+              sleep 10
             fi
+          done
+
+          if [ -z "$POD_NAME" ]; then
+            echo "Failed to find the pod after 5 attempts."
+          fi
 
       - name: Remove completed pods and jobs (cronjobs)
         run: |

--- a/.github/workflows/.tools-cleanup.yml
+++ b/.github/workflows/.tools-cleanup.yml
@@ -9,6 +9,29 @@ jobs:
     environment: tools
     runs-on: ubuntu-24.04
     steps:
+      - name: Scale down legacy
+        continue-on-error: true
+        uses: bcgov/action-oc-runner@v1.0.0
+        with:
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ secrets.oc_server }}
+          commands: |
+            oc scale deployment/nr-forest-client-${{ github.event.number }}-legacy --replicas=0 -n ${{ secrets.OC_NAMESPACE }}
+            undesired_replicas=0
+
+            while true; do
+              available_replicas=$(oc get deployment/nr-forest-client-${{ github.event.number }}-legacy -n ${{ secrets.OC_NAMESPACE }} -o jsonpath='{.status.availableReplicas}')
+
+              if [[ "$available_replicas" -ge "$undesired_replicas" ]]; then
+                echo "DeploymentConfig ${{ secrets.OC_NAMESPACE }}-${{ github.event.number }}-legacy is now available with $available_replicas replicas."
+                break
+              fi
+
+              echo "Waiting... ($available_replicas pods available)"
+              sleep 5
+            done
+
       - name: Remove the PR database
         continue-on-error: true
         uses: bcgov/action-oc-runner@v1.0.0

--- a/.github/workflows/.tools-deploy.yml
+++ b/.github/workflows/.tools-deploy.yml
@@ -37,16 +37,16 @@ jobs:
           oc_server: ${{ secrets.oc_server }}
           commands: |
             oc scale deployment/nr-forest-client-${{ github.event.number }}-legacy --replicas=0 -n ${{ secrets.OC_NAMESPACE }}
-            undesired_replicas=0  
+            undesired_replicas=0
 
             while true; do
               available_replicas=$(oc get deployment/nr-forest-client-${{ github.event.number }}-legacy -n ${{ secrets.OC_NAMESPACE }} -o jsonpath='{.status.availableReplicas}')
-              
+
               if [[ "$available_replicas" -ge "$undesired_replicas" ]]; then
                 echo "DeploymentConfig ${{ secrets.OC_NAMESPACE }}-${{ github.event.number }}-legacy is now available with $available_replicas replicas."
                 break
               fi
-              
+
               echo "Waiting... ($available_replicas pods available)"
               sleep 5
             done

--- a/frontend/junk.txt
+++ b/frontend/junk.txt
@@ -1,0 +1,1 @@
+junk commit

--- a/frontend/junk.txt
+++ b/frontend/junk.txt
@@ -1,1 +1,0 @@
-junk commit


### PR DESCRIPTION
Tools namespace had been filling up. This should help.

Replaces #1533

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-34-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-34-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)