### PR TITLE
fix(be:FSADT1-1775): Ensure "Client created" record appears last

### DIFF
--- a/legacy/src/main/java/ca/bc/gov/app/service/ClientService.java
+++ b/legacy/src/main/java/ca/bc/gov/app/service/ClientService.java
@@ -14,6 +14,7 @@ import io.micrometer.observation.annotation.Observed;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -250,6 +251,13 @@ public class ClientService {
                 return Flux.error(
                     new NoValueFoundException("Client with number: " + clientNumber));
               }
+              
+              list
+                .sort(
+                  Comparator.comparing((Pair<HistoryLogDto, Integer> pair) ->
+                    pair.getLeft().updateTimestamp()
+                )
+                .reversed());
 
               log.info("Total history logs found for client {}: {}", clientNumber, list.size());
               return Flux.fromIterable(list);

--- a/legacy/src/main/java/ca/bc/gov/app/service/ClientService.java
+++ b/legacy/src/main/java/ca/bc/gov/app/service/ClientService.java
@@ -252,12 +252,18 @@ public class ClientService {
                     new NoValueFoundException("Client with number: " + clientNumber));
               }
               
-              list
-                .sort(
-                  Comparator.comparing((Pair<HistoryLogDto, Integer> pair) ->
-                    pair.getLeft().updateTimestamp()
-                )
-                .reversed());
+              list.sort(
+                  Comparator
+                      .comparing(
+                          (Pair<HistoryLogDto, Integer> pair) ->
+                              "Client created".equals(pair.getLeft().identifierLabel()) ? 1 : 0
+                      )
+                      .thenComparing(
+                          (Pair<HistoryLogDto, Integer> pair) ->
+                              pair.getLeft().updateTimestamp(),
+                          Comparator.reverseOrder()
+                      )
+              );
 
               log.info("Total history logs found for client {}: {}", clientNumber, list.size());
               return Flux.fromIterable(list);


### PR DESCRIPTION
Due to incorrect or records with same timestamps and based on business requirements, 
when client information is selected, the "Client created" record must appear 
as the last entry in the sorted history log.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-33-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)