### PR TITLE
feat(FSADT1-1855): Adjusted address lines to be displayed as a group

### DIFF
--- a/frontend/src/assets/styles/global.scss
+++ b/frontend/src/assets/styles/global.scss
@@ -962,6 +962,19 @@ del {
   color: var(--cds-helper-text, #79797B);
 }
 
+.table-container {
+  display: table;
+}
+
+.table-row {
+  display: table-row;
+}
+
+.table-cell {
+  display: table-cell;
+  padding-right: 0.5rem;
+}
+
 .divider {
   margin: 1.5rem 0 1.5rem 0;
 }

--- a/frontend/src/pages/client-details/HistoryView.vue
+++ b/frontend/src/pages/client-details/HistoryView.vue
@@ -6,6 +6,7 @@ import { useRouter } from 'vue-router';
 import {
         getLabelByColumnName, 
         getTagColorByClientStatus, 
+        getFormattedHtml,
         fieldActionMap, 
         removePrefix 
       } from "@/services/ForestClientService";
@@ -77,14 +78,13 @@ watch(
 
 const fieldReasonPriorityMap: { [actionCode: string]: string[] } = {
   "ADDR": [
-    "addressOne",
-    "addressTwo",
-    "addressThree",
+    "address",
     "city",
     "provinceDesc",
     "stateDesc",
     "countryDesc",
-    "postalCode"
+    "postalCode",
+    "zipCode",
   ],
   "ID": [
     "clientIdTypeDesc",
@@ -97,6 +97,7 @@ const getReasonForColumn = (
   columnName: string
 ): string | null => {
   const possibleActionCodes = fieldActionMap[columnName];
+  console.log(possibleActionCodes, historyLog, columnName);
   if (!possibleActionCodes || !historyLog.reasons || historyLog.reasons.length === 0) {
     return null;
   }
@@ -230,21 +231,27 @@ const userSearchSvg = useSvg(UserSearch);
                 <p class="label-02" v-if="getLabelByColumnName(historyDtlsLog.columnName)">
                   {{ getLabelByColumnName(historyDtlsLog.columnName) }}
                 </p>
+          
                 <p>
-                  <span v-if="historyDtlsLog.oldValue">
-                    <del class="helper-text">{{ historyDtlsLog.oldValue }}</del>&nbsp;
-                  </span>
+                  <div class="table-container">
+                    <div class="table-row">
+                      <div class="table-cell" v-if="historyDtlsLog.oldValue">
+                        <del class="helper-text">
+                          <span v-dompurify-html="getFormattedHtml(historyDtlsLog.oldValue)"></span>
+                        </del>&nbsp;
+                      </div>
+                      <div class="table-cell">
+                        <span v-if="historyDtlsLog.columnName === 'clientStatusDesc' ||
+                                    historyDtlsLog.columnName === 'locnExpiredInd'">
+                          <cds-tag :type="getTagColorByClientStatus(historyDtlsLog.newValue)">
+                            <span>{{ historyDtlsLog.newValue }}</span>
+                          </cds-tag>
+                        </span>
 
-                  <span v-if="historyDtlsLog.columnName === 'clientStatusDesc' ||
-                              historyDtlsLog.columnName === 'locnExpiredInd'">
-                    <cds-tag :type="getTagColorByClientStatus(historyDtlsLog.newValue)">
-                      <span>{{ historyDtlsLog.newValue }}</span>
-                    </cds-tag>
-                  </span>
-
-                  <span v-else>
-                      {{ historyDtlsLog.newValue }}
-                  </span>
+                        <span v-else v-dompurify-html="getFormattedHtml(historyDtlsLog.newValue)"></span>
+                      </div>
+                    </div>
+                  </div>
                 </p>
 
                 <div v-if="getReasonForColumn(historyLog, historyDtlsLog.columnName)"

--- a/frontend/src/services/ForestClientService.ts
+++ b/frontend/src/services/ForestClientService.ts
@@ -626,6 +626,7 @@ const columnNameToLabelMap: Record<string, string> = {
   stateDesc: "State",
   countryDesc: "Country",
   postalCode: "Postal code",
+  zipCode: "Zip code",
   trustLocationInd: "Trust location",
   contactTypeDesc: "Contact type",
   associatedLocation: "Associated location",

--- a/frontend/src/services/ForestClientService.ts
+++ b/frontend/src/services/ForestClientService.ts
@@ -211,6 +211,7 @@ export const fieldActionMap: { [key: string]: string[] } = {
   'legalFirstName': ['NAME'],
   'legalMiddleName': ['NAME'],
   'fullName': ['NAME'],
+  'address': ['ADDR'],
   'addressOne': ['ADDR'],
   'addressTwo': ['ADDR'],
   'addressThree': ['ADDR'],
@@ -220,6 +221,7 @@ export const fieldActionMap: { [key: string]: string[] } = {
   'provinceDesc': ['ADDR'],
   'countryDesc': ['ADDR'],
   'postalCode': ['ADDR'],
+  'zipCode': ['ADDR'],
   'clientStatusDesc': ['ACDC', 'DAC', 'RACT', 'USPN', 'SPN'],
 };
 
@@ -614,6 +616,7 @@ const columnNameToLabelMap: Record<string, string> = {
   locnExpiredInd: "Location status",
   clientComment: "Notes",
   locationName: "Location name",
+  address: "Address",
   addressOne: "Street address or PO box",
   addressTwo: "Delivery information",
   addressThree: "Additional delivery information",

--- a/frontend/stub/__files/response-client-history-source-LOC.json
+++ b/frontend/stub/__files/response-client-history-source-LOC.json
@@ -8,14 +8,9 @@
     "changeType": "UPD",
     "details": [
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": "ADDRESS1",
-        "newValue": "5473 Oak St"
-      },
-      {
-        "columnName": "addressTwo",
-        "oldValue": "ADDRESS2",
-        "newValue": "Unit 101"
+        "newValue": "Unit 101<br>5473 Oak St"
       }
     ],
     "reasons": [
@@ -44,14 +39,9 @@
         "newValue": "ANOTHER LOCATION"
       },
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": null,
         "newValue": "ADDRESS1"
-      },
-      {
-        "columnName": "addressTwo",
-        "oldValue": null,
-        "newValue": "ADDRESS2"
       },
       {
         "columnName": "city",
@@ -105,14 +95,9 @@
         "newValue": "TEST LOCATION"
       },
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": null,
         "newValue": "940 TOAT RD"
-      },
-      {
-        "columnName": "addressThree",
-        "oldValue": null,
-        "newValue": "3"
       },
       {
         "columnName": "city",
@@ -159,16 +144,6 @@
         "columnName": "locationName",
         "oldValue": "THISISATEST",
         "newValue": "THIS IS ATEST"
-      },
-      {
-        "columnName": "addressTwo",
-        "oldValue": null,
-        "newValue": "COMP 1"
-      },
-      {
-        "columnName": "addressThree",
-        "oldValue": null,
-        "newValue": "COMP 2"
       }
     ],
     "reasons": [
@@ -218,7 +193,7 @@
         "newValue": "THISISATEST"
       },
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": null,
         "newValue": "840-330 ST MARY AVE"
       },
@@ -400,7 +375,7 @@
     "changeType": "UPD",
     "details": [
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": "2404 DOUGLAS ST",
         "newValue": "2404 DOUGLAS STREET"
       }
@@ -499,7 +474,7 @@
         "newValue": "MAILING ADDRESS"
       },
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": null,
         "newValue": "2404 DOUGLAS ST"
       },

--- a/frontend/stub/__files/response-client-history.json
+++ b/frontend/stub/__files/response-client-history.json
@@ -50,14 +50,9 @@
     "changeType": "UPD",
     "details": [
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": "ADDRESS1",
-        "newValue": "5473 Oak St"
-      },
-      {
-        "columnName": "addressTwo",
-        "oldValue": "ADDRESS2",
-        "newValue": "Unit 101"
+        "newValue": "Unit 101<br>5473 Oak St"
       }
     ],
     "reasons": [
@@ -86,14 +81,9 @@
         "newValue": "ANOTHER LOCATION"
       },
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": null,
         "newValue": "ADDRESS1"
-      },
-      {
-        "columnName": "addressTwo",
-        "oldValue": null,
-        "newValue": "ADDRESS2"
       },
       {
         "columnName": "city",
@@ -173,14 +163,9 @@
         "newValue": "TEST LOCATION"
       },
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": null,
         "newValue": "940 TOAT RD"
-      },
-      {
-        "columnName": "addressThree",
-        "oldValue": null,
-        "newValue": "3"
       },
       {
         "columnName": "city",
@@ -227,16 +212,6 @@
         "columnName": "locationName",
         "oldValue": "THISISATEST",
         "newValue": "THIS IS ATEST"
-      },
-      {
-        "columnName": "addressTwo",
-        "oldValue": null,
-        "newValue": "COMP 1"
-      },
-      {
-        "columnName": "addressThree",
-        "oldValue": null,
-        "newValue": "COMP 2"
       }
     ],
     "reasons": [
@@ -286,7 +261,7 @@
         "newValue": "THISISATEST"
       },
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": null,
         "newValue": "840-330 ST MARY AVE"
       },
@@ -749,7 +724,7 @@
     "changeType": "UPD",
     "details": [
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": "2404 DOUGLAS ST",
         "newValue": "2404 DOUGLAS STREET"
       }
@@ -1155,7 +1130,7 @@
         "newValue": "MAILING ADDRESS"
       },
       {
-        "columnName": "addressOne",
+        "columnName": "address",
         "oldValue": null,
         "newValue": "2404 DOUGLAS ST"
       },

--- a/legacy/src/main/java/ca/bc/gov/app/repository/ForestClientQueries.java
+++ b/legacy/src/main/java/ca/bc/gov/app/repository/ForestClientQueries.java
@@ -155,18 +155,16 @@ public final class ForestClientQueries {
             END AS LOCN_EXPIRED_IND,
             AL.CLIENT_LOCN_NAME,
             TRIM(
-                COALESCE(AL.ADDRESS_1, '') ||
-                CASE
-                    WHEN AL.ADDRESS_2 IS NOT NULL THEN '<br>' || AL.ADDRESS_2
-                    ELSE ''
-                END ||
-                CASE
-                    WHEN AL.ADDRESS_3 IS NOT NULL THEN
-                        CASE
-                            WHEN AL.ADDRESS_2 IS NOT NULL THEN '<br>'
-                        END || AL.ADDRESS_3
-                    ELSE ''
-                END
+              COALESCE(AL.ADDRESS_1, '') ||
+              CASE
+                WHEN AL.ADDRESS_2 IS NOT NULL THEN '<br>' || AL.ADDRESS_2
+                ELSE ''
+              END ||
+              CASE
+                WHEN AL.ADDRESS_3 IS NOT NULL THEN
+                  '<br>' || AL.ADDRESS_3
+                ELSE ''
+              END
             ) AS ADDRESS,
             AL.CITY,
             CASE

--- a/legacy/src/main/java/ca/bc/gov/app/repository/ForestClientQueries.java
+++ b/legacy/src/main/java/ca/bc/gov/app/repository/ForestClientQueries.java
@@ -154,23 +154,45 @@ public final class ForestClientQueries {
                 WHEN AL.LOCN_EXPIRED_IND = 'N' THEN 'Active'
             END AS LOCN_EXPIRED_IND,
             AL.CLIENT_LOCN_NAME,
-            AL.ADDRESS_2,
-            AL.ADDRESS_3,
-            AL.ADDRESS_1,
+            TRIM(
+                COALESCE(AL.ADDRESS_1, '') ||
+                CASE
+                    WHEN AL.ADDRESS_2 IS NOT NULL THEN
+                        CASE WHEN AL.ADDRESS_1 IS NOT NULL THEN '<br>' END || AL.ADDRESS_2
+                    ELSE ''
+                END ||
+                CASE
+                    WHEN AL.ADDRESS_3 IS NOT NULL THEN
+                        CASE
+                            WHEN AL.ADDRESS_1 IS NOT NULL OR AL.ADDRESS_2 IS NOT NULL THEN '<br>'
+                        END || AL.ADDRESS_3
+                    ELSE ''
+                END
+            ) AS ADDRESS,
             AL.CITY,
             CASE
-                WHEN UPPER(AL.COUNTRY) = 'USA' OR UPPER(AL.COUNTRY) = 'US' OR UPPER(AL.COUNTRY) = 'UNITED STATES OF AMERICA'
+                WHEN UPPER(AL.COUNTRY) IN ('USA', 'US', 'UNITED STATES OF AMERICA')
                     THEN PC.PROVINCE_STATE_NAME
                 ELSE NULL
             END AS STATE_DESC,
             CASE
-                WHEN UPPER(AL.COUNTRY) = 'USA' OR UPPER(AL.COUNTRY) = 'US' OR UPPER(AL.COUNTRY) = 'UNITED STATES OF AMERICA'
+                WHEN UPPER(AL.COUNTRY) IN ('USA', 'US', 'UNITED STATES OF AMERICA')
                     THEN NULL
                 WHEN PC.PROVINCE_STATE_NAME IS NULL THEN AL.PROVINCE
                 ELSE PC.PROVINCE_STATE_NAME
             END AS PROVINCE_DESC,
             AL.COUNTRY AS COUNTRY_DESC,
-            AL.POSTAL_CODE,
+            CASE 
+              WHEN UPPER(AL.COUNTRY) IN ('USA', 'US', 'UNITED STATES OF AMERICA') 
+                THEN AL.POSTAL_CODE 
+              ELSE NULL 
+            END AS ZIP_CODE,
+
+            CASE 
+              WHEN UPPER(AL.COUNTRY) IN ('USA', 'US', 'UNITED STATES OF AMERICA') 
+                THEN NULL 
+              ELSE AL.POSTAL_CODE 
+            END AS POSTAL_CODE,
             AL.EMAIL_ADDRESS,
             CASE 
               WHEN LENGTH(AL.BUSINESS_PHONE) = 10 AND REGEXP_LIKE(AL.BUSINESS_PHONE, '^\\d{10}$') THEN
@@ -239,14 +261,13 @@ public final class ForestClientQueries {
               CASE COL.COLUMN_NAME
                   WHEN 'locnExpiredInd' THEN B.LOCN_EXPIRED_IND
                   WHEN 'locationName' THEN B.CLIENT_LOCN_NAME
-                  WHEN 'addressTwo' THEN B.ADDRESS_2
-                  WHEN 'addressThree' THEN B.ADDRESS_3
-                  WHEN 'addressOne' THEN B.ADDRESS_1
+                  WHEN 'address' THEN B.ADDRESS
                   WHEN 'city' THEN B.CITY
                   WHEN 'provinceDesc' THEN B.PROVINCE_DESC
                   WHEN 'stateDesc' THEN B.STATE_DESC
                   WHEN 'countryDesc' THEN B.COUNTRY_DESC
                   WHEN 'postalCode' THEN B.POSTAL_CODE
+                  WHEN 'zipCode' THEN B.ZIP_CODE
                   WHEN 'emailAddress' THEN B.EMAIL_ADDRESS
                   WHEN 'businessPhone' THEN B.BUSINESS_PHONE
                   WHEN 'cellPhone' THEN B.CELL_PHONE
@@ -261,14 +282,13 @@ public final class ForestClientQueries {
                   CASE COL.COLUMN_NAME
                       WHEN 'locnExpiredInd' THEN B.LOCN_EXPIRED_IND
                       WHEN 'locationName' THEN B.CLIENT_LOCN_NAME
-                      WHEN 'addressTwo' THEN B.ADDRESS_2
-                      WHEN 'addressThree' THEN B.ADDRESS_3
-                      WHEN 'addressOne' THEN B.ADDRESS_1
+                      WHEN 'address' THEN B.ADDRESS
                       WHEN 'city' THEN B.CITY
                       WHEN 'provinceDesc' THEN B.PROVINCE_DESC
                       WHEN 'stateDesc' THEN B.STATE_DESC
                       WHEN 'countryDesc' THEN B.COUNTRY_DESC
                       WHEN 'postalCode' THEN B.POSTAL_CODE
+                      WHEN 'zipCode' THEN B.ZIP_CODE
                       WHEN 'emailAddress' THEN B.EMAIL_ADDRESS
                       WHEN 'businessPhone' THEN B.BUSINESS_PHONE
                       WHEN 'cellPhone' THEN B.CELL_PHONE
@@ -295,39 +315,37 @@ public final class ForestClientQueries {
               UNION ALL
               SELECT 'locationName' AS COLUMN_NAME, 2 AS FIELD_ORDER FROM DUAL
               UNION ALL
-              SELECT 'addressOne' AS COLUMN_NAME, 3 AS FIELD_ORDER FROM DUAL
+              SELECT 'address' AS COLUMN_NAME, 3 AS FIELD_ORDER FROM DUAL
               UNION ALL
-              SELECT 'addressTwo' AS COLUMN_NAME, 4 AS FIELD_ORDER FROM DUAL
+              SELECT 'city' AS COLUMN_NAME, 4 AS FIELD_ORDER FROM DUAL    
               UNION ALL
-              SELECT 'addressThree' AS COLUMN_NAME, 5 AS FIELD_ORDER FROM DUAL
+              SELECT 'provinceDesc' AS COLUMN_NAME, 5 AS FIELD_ORDER FROM DUAL 
               UNION ALL
-              SELECT 'city' AS COLUMN_NAME, 6 AS FIELD_ORDER FROM DUAL    
+              SELECT 'stateDesc' AS COLUMN_NAME, 6 AS FIELD_ORDER FROM DUAL 
               UNION ALL
-              SELECT 'provinceDesc' AS COLUMN_NAME, 7 AS FIELD_ORDER FROM DUAL 
+              SELECT 'countryDesc' AS COLUMN_NAME, 7 AS FIELD_ORDER FROM DUAL 
               UNION ALL
-              SELECT 'stateDesc' AS COLUMN_NAME, 8 AS FIELD_ORDER FROM DUAL 
+              SELECT 'postalCode' AS COLUMN_NAME, 8 AS FIELD_ORDER FROM DUAL  
               UNION ALL
-              SELECT 'countryDesc' AS COLUMN_NAME, 9 AS FIELD_ORDER FROM DUAL 
+              SELECT 'zipCode' AS COLUMN_NAME, 9 AS FIELD_ORDER FROM DUAL  
               UNION ALL
-              SELECT 'postalCode' AS COLUMN_NAME, 10 AS FIELD_ORDER FROM DUAL  
+              SELECT 'emailAddress' AS COLUMN_NAME, 10 AS FIELD_ORDER FROM DUAL    
               UNION ALL
-              SELECT 'emailAddress' AS COLUMN_NAME, 11 AS FIELD_ORDER FROM DUAL    
+              SELECT 'businessPhone' AS COLUMN_NAME, 11 AS FIELD_ORDER FROM DUAL  
               UNION ALL
-              SELECT 'businessPhone' AS COLUMN_NAME, 12 AS FIELD_ORDER FROM DUAL  
+              SELECT 'cellPhone' AS COLUMN_NAME, 12 AS FIELD_ORDER FROM DUAL  
               UNION ALL
-              SELECT 'cellPhone' AS COLUMN_NAME, 13 AS FIELD_ORDER FROM DUAL  
+              SELECT 'homePhone' AS COLUMN_NAME, 13 AS FIELD_ORDER FROM DUAL  
               UNION ALL
-              SELECT 'homePhone' AS COLUMN_NAME, 14 AS FIELD_ORDER FROM DUAL  
+              SELECT 'faxNumber' AS COLUMN_NAME, 14 AS FIELD_ORDER FROM DUAL
               UNION ALL
-              SELECT 'faxNumber' AS COLUMN_NAME, 15 AS FIELD_ORDER FROM DUAL
+              SELECT 'cliLocnComment' AS COLUMN_NAME, 15 AS FIELD_ORDER FROM DUAL
               UNION ALL
-              SELECT 'cliLocnComment' AS COLUMN_NAME, 16 AS FIELD_ORDER FROM DUAL
+              SELECT 'hdbsCompanyCode' AS COLUMN_NAME, 16 AS FIELD_ORDER FROM DUAL
               UNION ALL
-              SELECT 'hdbsCompanyCode' AS COLUMN_NAME, 17 AS FIELD_ORDER FROM DUAL
+              SELECT 'returnedMailDate' AS COLUMN_NAME, 17 AS FIELD_ORDER FROM DUAL
               UNION ALL
-              SELECT 'returnedMailDate' AS COLUMN_NAME, 18 AS FIELD_ORDER FROM DUAL
-              UNION ALL
-              SELECT 'trustLocationInd' AS COLUMN_NAME, 19 AS FIELD_ORDER FROM DUAL
+              SELECT 'trustLocationInd' AS COLUMN_NAME, 18 AS FIELD_ORDER FROM DUAL
           ) COL
       )
       SELECT
@@ -348,7 +366,7 @@ public final class ForestClientQueries {
           (OLD_VALUE IS NOT NULL AND NEW_VALUE IS NULL) OR
           (TRIM(OLD_VALUE) <> TRIM(NEW_VALUE))
       )
-      ORDER BY A.IDX DESC, A.FIELD_ORDER ASC    
+      ORDER BY A.IDX DESC, A.FIELD_ORDER ASC
       """;
   
   public static final String CONTACT_HISTORY = """

--- a/legacy/src/main/java/ca/bc/gov/app/repository/ForestClientQueries.java
+++ b/legacy/src/main/java/ca/bc/gov/app/repository/ForestClientQueries.java
@@ -157,14 +157,13 @@ public final class ForestClientQueries {
             TRIM(
                 COALESCE(AL.ADDRESS_1, '') ||
                 CASE
-                    WHEN AL.ADDRESS_2 IS NOT NULL THEN
-                        CASE WHEN AL.ADDRESS_1 IS NOT NULL THEN '<br>' END || AL.ADDRESS_2
+                    WHEN AL.ADDRESS_2 IS NOT NULL THEN '<br>' || AL.ADDRESS_2
                     ELSE ''
                 END ||
                 CASE
                     WHEN AL.ADDRESS_3 IS NOT NULL THEN
                         CASE
-                            WHEN AL.ADDRESS_1 IS NOT NULL OR AL.ADDRESS_2 IS NOT NULL THEN '<br>'
+                            WHEN AL.ADDRESS_2 IS NOT NULL THEN '<br>'
                         END || AL.ADDRESS_3
                     ELSE ''
                 END


### PR DESCRIPTION
- Adjusted address lines to be displayed as a group as per requested by Ziad
- Distinguished between zip code and postal code for labels

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-11-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)