### PR TITLE
fix(fe): use a static layout for the acronym

### DIFF
--- a/frontend/src/pages/client-details/SummaryView.vue
+++ b/frontend/src/pages/client-details/SummaryView.vue
@@ -372,8 +372,6 @@ watch(
 );
 
 const originalClient = computed(() => props.data.client);
-
-const isIndividual = computed(() => formData.value.client.clientTypeCode === "I");
 </script>
 
 <template>
@@ -506,62 +504,52 @@ const isIndividual = computed(() => formData.value.client.clientTypeCode === "I"
       @empty="validation.legalMiddleName = true"
       @error="validation.legalMiddleName = !$event"
     />
-    <div
-      :class="{
-        'display-contents': isIndividual,
-        'horizontal-input-grouping': !isIndividual,
-      }"
-      v-if="displayEditable('clientName') || displayEditable('acronym')"
+    <text-input-component
+      id="input-clientName"
+      v-if="displayEditable('clientName')"
+      :label="clientNameLabel"
+      autocomplete="off"
+      required
+      required-label
+      placeholder=""
+      v-model="formData.client.clientName"
+      :validations="[
+        ...getValidations('businessInformation.businessName'),
+        submissionValidation('businessInformation.businessName'),
+      ]"
+      @empty="validation.clientName = !$event"
+      @error="validation.clientName = !$event"
+    />
+    <text-input-component
+      id="input-acronym"
+      v-if="displayEditable('acronym')"
+      label="Acronym"
+      placeholder=""
+      mask="NNNNNNNN"
+      autocomplete="off"
+      v-model="formData.client.clientAcronym"
+      :validations="[
+        ...getValidations('businessInformation.clientAcronym'),
+        submissionValidation('/client/clientAcronym'),
+      ]"
+      enabled
+      @empty="validation.acronym = true"
+      @error="validation.acronym = !$event"
     >
-      <text-input-component
-        id="input-clientName"
-        v-if="displayEditable('clientName')"
-        :class="{ 'grouping-02--width-32rem': !isIndividual }"
-        :label="clientNameLabel"
-        autocomplete="off"
-        required
-        required-label
-        placeholder=""
-        v-model="formData.client.clientName"
-        :validations="[
-          ...getValidations('businessInformation.businessName'),
-          submissionValidation('businessInformation.businessName'),
-        ]"
-        @empty="validation.clientName = !$event"
-        @error="validation.clientName = !$event"
-      />
-      <text-input-component
-        id="input-acronym"
-        v-if="displayEditable('acronym')"
-        :class="{ 'grouping-02--width-8rem': !isIndividual }"
-        label="Acronym"
-        placeholder=""
-        mask="NNNNNNNN"
-        autocomplete="off"
-        v-model="formData.client.clientAcronym"
-        :validations="[
-          ...getValidations('businessInformation.clientAcronym'),
-          submissionValidation('/client/clientAcronym'),
-        ]"
-        enabled
-        @empty="validation.acronym = true"
-        @error="validation.acronym = !$event"
-      >
-        <template #error="{ data }">
-          <template v-if="typeof data === 'object' && data?.custom?.match">
-            Looks like this acronym belongs to client
-            <span
-              ><a
-                :href="`https://${greenDomain}/int/client/client02MaintenanceAction.do?bean.clientNumber=${data.custom.match}`"
-                target="_blank"
-                rel="noopener"
-                >{{ data.custom.match }}</a
-              ></span
-            >. Try another acronym
-          </template>
+      <template #error="{ data }">
+        <template v-if="typeof data === 'object' && data?.custom?.match">
+          Looks like this acronym belongs to client
+          <span
+            ><a
+              :href="`https://${greenDomain}/int/client/client02MaintenanceAction.do?bean.clientNumber=${data.custom.match}`"
+              target="_blank"
+              rel="noopener"
+              >{{ data.custom.match }}</a
+            ></span
+          >. Try another acronym
         </template>
-      </text-input-component>
-    </div>
+      </template>
+    </text-input-component>
     <text-input-component
       id="input-doingBusinessAs"
       v-if="displayEditable('doingBusinessAs')"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Applies a static layout for the fields Client name / Acronym. So it won't change dynamically according to the client type anymore.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->