### PR TITLE
fix(metrics): fixing some of the metrics histogram values

### DIFF
--- a/backend/src/main/java/ca/bc/gov/app/configuration/ForestClientMetricConfiguration.java
+++ b/backend/src/main/java/ca/bc/gov/app/configuration/ForestClientMetricConfiguration.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -58,7 +59,17 @@ public class ForestClientMetricConfiguration {
         return DistributionStatisticConfig
             .builder()
             .percentiles(0.5, 0.95, 0.99)
-            .percentilesHistogram(true)
+            .serviceLevelObjectives(
+                Duration.ofMillis(100).toNanos(),
+                Duration.ofMillis(250).toNanos(),
+                Duration.ofMillis(500).toNanos(),
+                Duration.ofSeconds(1).toNanos(),
+                Duration.ofSeconds(2).toNanos(),
+                Duration.ofSeconds(5).toNanos(),
+                Duration.ofSeconds(15).toNanos(),
+                Duration.ofSeconds(30).toNanos(),
+                Duration.ofMinutes(1).toNanos()
+            )
             .build()
             .merge(config);
       }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This PR updates the histogram configuration for metrics by replacing the previous percentile-histogram toggle with explicit service-level objective (SLO) durations in nanoseconds.

- Switched from `.percentilesHistogram(true)` to a series of `serviceLevelObjectives(...)` durations.
- Added `java.time.Duration` import to calculate nanosecond values.
- Defined SLO boundaries at various latency thresholds (100 ms up to 1 min).

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] No new tests are required


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-46-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-46-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)