### PR TITLE
feat(fe): allow the Date component to be used as optional

### DIFF
--- a/frontend/cypress/e2e/pages/staffform/BcRegisteredClientInformationWizardStep.cy.ts
+++ b/frontend/cypress/e2e/pages/staffform/BcRegisteredClientInformationWizardStep.cy.ts
@@ -701,7 +701,7 @@ describe("BC Registered Staff Wizard Step", () => {
       beforeEach(() => {
         cy.get("#birthdateYear").find("input").focus().blur();
 
-        cy.contains("#birthdate + .field-error", "Date of birth must include a year");
+        cy.contains("#birthdate + .field-error", "You must enter a date of birth");
       });
       it("enables the button Next when a new Client name from a different type gets selected", () => {
         cy.clearFormEntry("#businessName");

--- a/frontend/src/components/forms/DateInputComponent/index.vue
+++ b/frontend/src/components/forms/DateInputComponent/index.vue
@@ -173,8 +173,14 @@ const selectedYear = ref<string>(getDatePart(DatePart.year));
 const selectedMonth = ref<string>(getDatePart(DatePart.month));
 const selectedDay = ref<string>(getDatePart(DatePart.day));
 
-const buildFullDate = () =>
-  `${selectedYear.value}-${selectedMonth.value}-${selectedDay.value}`;
+const buildFullDate = () => {
+  let result = `${selectedYear.value}-${selectedMonth.value}-${selectedDay.value}`;
+  if (result === "--") {
+    // empty date
+    result = "";
+  }
+  return result;
+};
 
 // We set it as a separated ref due to props not being updatable
 const selectedValue = ref<string | null>(buildFullDate());
@@ -222,9 +228,29 @@ watch([selectedValue], () => {
   emitValueChange(selectedValue.value);
 });
 
+const clearError = (datePart: DatePart) => {
+  setError("", datePart);
+  validation[datePart] = true;
+};
+
+const clearAllErrors = () => {
+  clearError(DatePart.year);
+  clearError(DatePart.month);
+  clearError(DatePart.day);
+};
+
 // We call all the part validations
 const validatePart = (datePart: DatePart) => {
   const newValue = datePartRefs[datePart].value;
+
+  /*
+  Note: we check both the full value and the current part value due to synchronization issues.
+  */
+  if (!newValue && !selectedValue.value) {
+    clearAllErrors();
+    return true;
+  }
+
   const error = partValidators.value[datePart]
     .map((validation) => validation(newValue))
     .filter((errorMessage) => {

--- a/frontend/src/helpers/validators/BCeIDFormValidations.ts
+++ b/frontend/src/helpers/validators/BCeIDFormValidations.ts
@@ -28,6 +28,7 @@ formFieldValidations["businessInformation.businessName"] = [
 ];
 
 formFieldValidations["businessInformation.birthdate"] = [
+  isNotEmpty("You must enter a date of birth"),
   isDateInThePast("Date of birth must be in the past"),
   isMinimumYearsAgo(19, "You must be at least 19 years old to apply"),
 ];

--- a/frontend/src/helpers/validators/StaffFormValidations.ts
+++ b/frontend/src/helpers/validators/StaffFormValidations.ts
@@ -47,6 +47,7 @@ fieldValidations["businessInformation.clientType"] = [
 ];
 
 fieldValidations["businessInformation.birthdate"] = [
+  isNotEmpty("You must enter a date of birth"),
   isDateInThePast("Date of birth must be in the past"),
   isMinimumYearsAgo(19, "The applicant must be at least 19 years old to apply"),
 ];

--- a/frontend/tests/unittests/components/forms/DateInputComponent.spec.ts
+++ b/frontend/tests/unittests/components/forms/DateInputComponent.spec.ts
@@ -80,11 +80,12 @@ describe("Date Input Component", () => {
     });
     globalWrapper = wrapper;
 
-    await wrapper.find(`#${id}Year`).trigger("input");
-    await wrapper.find(`#${id}Year`).trigger("blur");
+    const inputWrapper = wrapper.find<HTMLInputElement>(`#${id}Year`);
+    await setInputValue(inputWrapper, "1");
+    await inputWrapper.trigger("blur");
 
     expect(wrapper.emitted("error")).toBeTruthy();
-    expect(wrapper.emitted("error")![0][0]).toBe("My date must include a year");
+    expect(wrapper.emitted("error")![0][0]).toBe("Year must have 4 digits");
   });
 
   it("revalidates when changed from outside (i.e. not directly by the user)", async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Allows the Date component to be used as optional.
Also updates the error message on forms when it's required - according to current business rules.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-27-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)