### PR TITLE
feat(fe:FSADT1-1993): DOB optional in the creation of an individual client type - frontend

### DIFF
--- a/frontend/cypress/e2e/pages/ClientDetailsPage.cy.ts
+++ b/frontend/cypress/e2e/pages/ClientDetailsPage.cy.ts
@@ -948,7 +948,7 @@ describe("Client Details Page", () => {
                 Prevents error with focus switching.
                 */
                 // cy.get("[data-focus='location-3-heading']:focus");
-                cy.wait(1000);
+                cy.wait(500);
 
                 cy.fillFormEntry("#name_null", "Beach office");
 
@@ -1055,7 +1055,7 @@ describe("Client Details Page", () => {
                 Prevents error with focus switching.
                 */
                 // cy.get("[data-focus='location-3-heading']:focus");
-                cy.wait(1000);
+                cy.wait(500);
 
                 cy.fillFormEntry("#name_null", "Beach office");
 
@@ -1453,7 +1453,7 @@ describe("Client Details Page", () => {
                 Prevents error with focus switching.
                 */
                 // cy.get("[data-focus='contact-null-heading']:focus");
-                cy.wait(1000);
+                cy.wait(500);
 
                 cy.fillFormEntry("#fullName_null", "Steve New");
 
@@ -1571,7 +1571,7 @@ describe("Client Details Page", () => {
                 Prevents error with focus switching.
                 */
                 // cy.get("[data-focus='contact-null-heading']:focus");
-                cy.wait(1000);
+                cy.wait(500);
 
                 cy.fillFormEntry("#fullName_null", "Steve New");
 
@@ -1681,7 +1681,7 @@ describe("Client Details Page", () => {
           Prevents error with focus switching.
           */
           // cy.get("[data-focus='contact-null-heading']:focus");
-          cy.wait(1000);
+          cy.wait(500);
 
           // Use the same contact name
           cy.fillFormEntry("#fullName_null", contactName);
@@ -1880,10 +1880,17 @@ describe("Client Details Page", () => {
 
           cy.get("#addClientRelationshipBtn").click();
 
+          /*
+          Wait to have a focused element.
+          Prevents error with focus switching.
+          */
+          // cy.get("[data-focus='relationships-location-null-heading']:focus");
+          cy.wait(500);
+
           fillInRequiredFields("01");
         });
 
-        it("shows the error on field Location name", () => {
+        it("shows the errors on the unique validation-related set of fields", () => {
           cy.get("#rc-null-null-location").should("have.attr", "invalid");
           cy.get("#rc-null-null-relationship").should("have.attr", "invalid");
           cy.get("#rc-null-null-relatedClient").should("have.attr", "invalid");
@@ -1967,7 +1974,7 @@ describe("Client Details Page", () => {
                 Prevents error with focus switching.
                 */
                 // cy.get("[data-focus='relationships-location-null-heading']:focus");
-                cy.wait(1000);
+                cy.wait(500);
 
                 fillInRequiredFields("01 - Accountant address");
 
@@ -2092,7 +2099,7 @@ describe("Client Details Page", () => {
                 Prevents error with focus switching.
                 */
                 // cy.get("[data-focus='location-3-heading']:focus");
-                cy.wait(1000);
+                cy.wait(500);
 
                 fillInRequiredFields("01 - Accountant address");
 

--- a/frontend/src/components/forms/DateInputComponent/index.vue
+++ b/frontend/src/components/forms/DateInputComponent/index.vue
@@ -521,8 +521,8 @@ const datePartComponentRefs = {
 </style>
 
 <template>
-  <div aria-live="polite">
-    <div class="grouping-02" v-if="enabled" :id="id">
+  <div aria-live="polite" v-if="enabled" :id="id">
+    <div class="grouping-02">
       <date-input-part
         :ref="datePartComponentRefs[DatePart.year]"
         :parent-id="id"

--- a/frontend/src/components/forms/DateInputComponent/index.vue
+++ b/frontend/src/components/forms/DateInputComponent/index.vue
@@ -186,14 +186,13 @@ const buildFullDate = () => {
 const selectedValue = ref<string | null>(buildFullDate());
 
 const areAllPartsValid = () =>
-  validation[DatePart.year] &&
-  validation[DatePart.month] &&
-  validation[DatePart.day];
+  validation[DatePart.year] && validation[DatePart.month] && validation[DatePart.day];
 
 const isAnyPartEmpty = () =>
-  isEmpty(selectedYear.value) ||
-  isEmpty(selectedMonth.value) ||
-  isEmpty(selectedDay.value);
+  isEmpty(selectedYear.value) || isEmpty(selectedMonth.value) || isEmpty(selectedDay.value);
+
+const areAllPartsEmpty = () =>
+  isEmpty(selectedYear.value) && isEmpty(selectedMonth.value) && isEmpty(selectedDay.value);
 
 // We set the value prop as a reference for update reason
 emit("empty", isAnyPartEmpty());
@@ -212,7 +211,9 @@ const emitValueChange = (newValue: string): void => {
   emit("empty", someEmpty);
   if (focusedPart.value !== null) {
     let possiblyValid = false;
-    if (!someEmpty) {
+    if (someEmpty) {
+      possiblyValid = !props.required && areAllPartsEmpty();
+    } else {
       const otherParts = getPartsExcept(focusedPart.value);
       const allOtherAreValid = otherParts.every((part) => validation[part]);
       if (allOtherAreValid) {

--- a/frontend/src/components/forms/DateInputComponent/index.vue
+++ b/frontend/src/components/forms/DateInputComponent/index.vue
@@ -239,6 +239,19 @@ const clearAllErrors = () => {
   clearError(DatePart.day);
 };
 
+/**
+ * Turns the other date parts invalid, unless they have a non-empty value.
+ * @param datePart - the date part not to be affected by this call
+ */
+const invalidateOtherMissingParts = (datePart: DatePart) => {
+  const parts = [DatePart.year, DatePart.month, DatePart.day];
+  parts.forEach((curPart) => {
+    if (curPart !== datePart && !datePartRefs[curPart].value) {
+      validation[curPart] = false;
+    }
+  });
+};
+
 // We call all the part validations
 const validatePart = (datePart: DatePart) => {
   const newValue = datePartRefs[datePart].value;
@@ -247,8 +260,12 @@ const validatePart = (datePart: DatePart) => {
   Note: we check both the full value and the current part value due to synchronization issues.
   */
   if (!newValue && !selectedValue.value) {
+    // everything is empty
     clearAllErrors();
     return true;
+  } else {
+    // reset validation for the missing parts
+    invalidateOtherMissingParts(datePart);
   }
 
   const error = partValidators.value[datePart]

--- a/frontend/src/helpers/validators/StaffFormValidations.ts
+++ b/frontend/src/helpers/validators/StaffFormValidations.ts
@@ -46,11 +46,19 @@ fieldValidations["businessInformation.clientType"] = [
   isNotEmpty("You must select a client type."),
 ];
 
-fieldValidations["businessInformation.birthdate"] = [
-  isNotEmpty("You must enter a date of birth"),
+const birthdateBaseValidations = [
   isDateInThePast("Date of birth must be in the past"),
   isMinimumYearsAgo(19, "The applicant must be at least 19 years old to apply"),
 ];
+
+fieldValidations["businessInformation.birthdate"] = [
+  isNotEmpty("You must enter a date of birth"),
+  ...birthdateBaseValidations,
+];
+
+fieldValidations["businessInformation.birthdate-admin"] = birthdateBaseValidations.map(
+  (validation) => optional(validation),
+);
 
 // use the same validations as firstName in contacts
 fieldValidations["businessInformation.firstName"] = [

--- a/frontend/src/pages/FormStaffPage.vue
+++ b/frontend/src/pages/FormStaffPage.vue
@@ -18,6 +18,7 @@ import {
   type ValidationMessageType,
   type FuzzyMatcherEvent,
   type FuzzyMatchResult,
+  type UserRole,
 } from "@/dto/CommonTypesDto";
 import {
   emptyContact,
@@ -53,11 +54,9 @@ import ForestClientUserSession from "@/helpers/ForestClientUserSession";
 import ArrowRight16 from "@carbon/icons-vue/es/arrow--right/16";
 import Check16 from "@carbon/icons-vue/es/checkmark/16";
 
-const isAdminInd = computed(() =>
-  ["CLIENT_ADMIN"].some((authority) =>
-    ForestClientUserSession.authorities.includes(authority)
-  )
-);
+const userRoles = ForestClientUserSession.authorities as UserRole[];
+
+const isAdminInd = computed(() => userRoles.includes("CLIENT_ADMIN"));
 
 const clientTypesList = computed(() => {
   const list: CodeNameType[] = [
@@ -566,6 +565,7 @@ watch(submissionLimitError, () => {
             v-if="clientType?.code === 'I'"
             :active="currentTab == 0"
             :data="formData"
+            :user-roles="userRoles"
             @valid="validateStep"
           />
           

--- a/frontend/src/pages/staffform/IndividualClientInformationWizardStep.vue
+++ b/frontend/src/pages/staffform/IndividualClientInformationWizardStep.vue
@@ -10,10 +10,7 @@ import { useFocus } from "@/composables/useFocus";
 import { useEventBus } from "@vueuse/core";
 // Importing types
 import type { FormDataDto } from "@/dto/ApplyClientNumberDto";
-import type {
-  CodeNameType,
-  IdentificationCodeNameType,
-} from "@/dto/CommonTypesDto";
+import type { CodeNameType, IdentificationCodeNameType, UserRole } from "@/dto/CommonTypesDto";
 // Importing validators
 import {
   getValidations,
@@ -28,12 +25,21 @@ const props = defineProps<{
   data: FormDataDto;
   active: boolean;
   autoFocus?: boolean;
+  userRoles: UserRole[];
 }>();
 
 const emit = defineEmits<{
   (e: "update:data", value: FormDataDto): void;
   (e: "valid", value: boolean): void;
 }>();
+
+const isAdmin = computed(() => props.userRoles.includes("CLIENT_ADMIN"));
+
+const isBirthdateRequired = computed(() => !isAdmin.value);
+
+const birthdateValidationKey = computed(() =>
+  isAdmin.value ? "businessInformation.birthdate-admin" : "businessInformation.birthdate",
+);
 
 // Set the prop as a ref, and then emit when it changes
 const formData = ref<FormDataDto>(props.data);
@@ -136,7 +142,7 @@ const validation = reactive<Record<string, boolean>>({
   firstName: false,
   middleName: true,
   lastName: false,
-  birthdate: false,
+  birthdate: !isBirthdateRequired.value,
   identificationType: false,
   identificationProvince: !shouldDisplayProvince.value,
   clientIdentification: false,
@@ -326,7 +332,7 @@ watch(combinedValue, (newValue) => {
     <div>
       <div class="label-with-icon line-height-0 parent-label">
         <div class="cds-text-input-label">
-          <span class="cds-text-input-required-label">* </span>
+          <span class="cds-text-input-required-label" v-if="isBirthdateRequired">* </span>
           <span>Date of birth</span>
         </div>
         <cds-tooltip>
@@ -343,13 +349,13 @@ watch(combinedValue, (newValue) => {
         v-model="formData.businessInformation.birthdate"
         :enabled="true"
         :validations="[
-          ...getValidations('businessInformation.birthdate'),
-          submissionValidation('businessInformation.birthdate'),
+          ...getValidations(birthdateValidationKey),
+          submissionValidation(birthdateValidationKey),
         ]"
         :year-validations="[...getValidations('businessInformation.birthdate.year')]"
         @error="validation.birthdate = !$event"
         @possibly-valid="validation.birthdate = $event"
-        required
+        :required="isBirthdateRequired"
       />
     </div>
 

--- a/frontend/tests/components/pages/client-details/ClientRelationshipRow.cy.ts
+++ b/frontend/tests/components/pages/client-details/ClientRelationshipRow.cy.ts
@@ -74,9 +74,7 @@ describe("<client-relationships-row />", () => {
     userRoles: ["CLIENT_EDITOR"],
   });
 
-  const operateRelatedClientStub: OperateRelatedClient = () => {
-    alert("hey");
-  };
+  const operateRelatedClientStub: OperateRelatedClient = () => {};
   const operateRelatedClientWrapper = {
     operateRelatedClient: operateRelatedClientStub,
   };

--- a/frontend/tests/components/pages/staffform/IndividualClientInformationWizardStep.cy.ts
+++ b/frontend/tests/components/pages/staffform/IndividualClientInformationWizardStep.cy.ts
@@ -38,6 +38,7 @@ describe("<individual-client-information-wizard-step />", () => {
         ],
       },
     } as unknown as FormDataDto,
+    userRoles: ["CLIENT_EDITOR"],
   });
 
   let currentProps = null;
@@ -129,6 +130,31 @@ describe("<individual-client-information-wizard-step />", () => {
   });
 
   describe("validation", () => {
+    describe("Date of birth", () => {
+      beforeEach(() => {
+        mount();
+      });
+
+      it("requires a Date of birth to be entered (by default)", () => {
+        cy.clearFormEntry("#birthdateYear");
+        cy.get("#birthdateYear").should("have.attr", "invalid");
+        cy.get("#birthdate").should("contain", "You must enter a date of birth");
+      });
+
+      describe("when user is admin", () => {
+        beforeEach(() => {
+          const props = getDefaultProps();
+          props.userRoles = ["CLIENT_ADMIN"];
+          mount(props);
+        });
+
+        it("doesn't require a Date of birth to be entered", () => {
+          cy.clearFormEntry("#birthdateYear");
+          cy.get("#birthdateYear").should("not.have.attr", "invalid");
+          cy.get("#birthdate").should("not.contain", "You must enter a date of birth");
+        });
+      });
+    });
     describe("ID number according to the current ID type (and identificationProvince)", () => {
       beforeEach(() => {
         mount();

--- a/frontend/tests/unittests/components/forms/DateInputComponent.spec.ts
+++ b/frontend/tests/unittests/components/forms/DateInputComponent.spec.ts
@@ -225,6 +225,65 @@ describe("Date Input Component", () => {
     expect(wrapper.emitted("possibly-valid")![0][0]).toBe(false);
   });
 
+  describe("when it's not a required field", () => {
+    beforeEach(() => {
+      const wrapper = mount(DateInputComponent, {
+        props: {
+          id,
+          title: "My date",
+          modelValue: "2000--",
+          validations: [],
+          enabled: true,
+          required: false,
+        },
+        directives: {
+          masked: () => {},
+        },
+        attachTo: document.body,
+      });
+      globalWrapper = wrapper;
+    });
+
+    it("emits possibly-valid true when it gets all emptied", async () => {
+      const wrapper = globalWrapper;
+
+      const inputWrapper = wrapper.find<HTMLInputElement>(`#${id}Year`);
+      await setInputValue(inputWrapper, "");
+
+      expect(wrapper.emitted("possibly-valid")).toBeTruthy();
+      expect(wrapper.emitted("possibly-valid")![0][0]).toBe(true);
+    });
+  });
+
+  describe("when it's a required field", () => {
+    beforeEach(() => {
+      const wrapper = mount(DateInputComponent, {
+        props: {
+          id,
+          title: "My date",
+          modelValue: "2000--",
+          validations: [],
+          enabled: true,
+          required: true,
+        },
+        directives: {
+          masked: () => {},
+        },
+        attachTo: document.body,
+      });
+      globalWrapper = wrapper;
+    });
+
+    it("emits possibly-valid false when it gets all emptied", async () => {
+      const wrapper = globalWrapper;
+      const inputWrapper = wrapper.find<HTMLInputElement>(`#${id}Year`);
+      await setInputValue(inputWrapper, "");
+
+      expect(wrapper.emitted("possibly-valid")).toBeTruthy();
+      expect(wrapper.emitted("possibly-valid")![0][0]).toBe(false);
+    });
+  });
+
   describe.each([
     {
       partName: "Year",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Makes the Date of birth optional for creating an Individual client when user is CLIENT_ADMIN.

To achieve that goal, the Date input component was further enhanced (in addition to what was made on #1777).

Also improves an unrelated test on the ClientDetailsPage.

Fixes [FSADT1-1993](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT1-1993)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->