### PR TITLE
fix(be): Upgraded Reactor Netty and Netty to resolve a regression wit…

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -87,8 +87,6 @@
         <mockito.version>5.20.0</mockito.version>
         <jooq.version>3.20.10</jooq.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
-        <reactor-netty-http.version>1.3.1</reactor-netty-http.version>
-        <netty-bom.version>4.2.9.Final</netty-bom.version>
     </properties>
 
     <dependencies>
@@ -362,18 +360,6 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.projectreactor.netty</groupId>
-                <artifactId>reactor-netty-http</artifactId>
-                <version>${reactor-netty-http.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/legacy/openshift.deploy.yml
+++ b/legacy/openshift.deploy.yml
@@ -156,12 +156,6 @@ objects:
                   value: America/Vancouver
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
-                - name: JAVA_TOOL_OPTIONS
-                  value: >
-                    -Dio.netty.noUnsafe=true
-                    -Dio.netty.noKeySetOptimization=true
-                    -Dio.netty.recycler.maxCapacityPerThread=0
-                    -Dio.netty.allocator.numDirectArenas=0
               ports:
                 - containerPort: 9000
                   protocol: TCP

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -52,8 +52,6 @@
     <selenium.version>4.39.0</selenium.version>
     <mockito.version>5.20.0</mockito.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
-    <reactor-netty-http.version>1.3.1</reactor-netty-http.version>
-    <netty-bom.version>4.2.9.Final</netty-bom.version>
   </properties>
 
   <dependencies>
@@ -253,18 +251,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.projectreactor.netty</groupId>
-        <artifactId>reactor-netty-http</artifactId>
-        <version>${reactor-netty-http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${netty-bom.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -49,8 +49,6 @@
     <flyway.version>11.11.1</flyway.version>
     <opentelemetry.version>1.57.0</opentelemetry.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
-    <reactor-netty-http.version>1.3.1</reactor-netty-http.version>
-    <netty-bom.version>4.2.9.Final</netty-bom.version>
   </properties>
 
   <dependencies>
@@ -233,18 +231,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.projectreactor.netty</groupId>
-        <artifactId>reactor-netty-http</artifactId>
-        <version>${reactor-netty-http.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${netty-bom.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Upgrade Reactor Netty and Netty to resolve a request decoding issue affecting WebFlux CORS handling.

With older Netty versions, encoded URIs caused decoding failures at the Netty layer, leading to OPTIONS preflight requests returning 400 before Spring Security or CORS filters were applied. This manifested as browser CORS errors despite correct configuration.

Updating to newer Netty/Reactor Netty versions fixes the decoding behavior and restores proper CORS handling.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-37-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)