### PR TITLE
fix(ci): allow pages permission in scheduled SchemaSpy workflow

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -16,6 +16,7 @@ jobs:
     name: SchemaSpy Documentation
     permissions:
       contents: write
+      pages: write
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.schema-spy.yml@6d695dd755fa9255ea4bde335890516beb6f95e4 # v1.0.1
     with:
       flyway_locations: 'filesystem:./backend/src/main/resources/db/migration'


### PR DESCRIPTION
## Summary
- add \'pages: write\' to the  job in 
- align caller job permissions with the reusable workflow requirements
- fix GitHub Actions validation error: workflow requested  while caller allowed 

## Testing
- validated workflow syntax intent by ensuring required job permission is explicitly declared

## Risk
- low; CI permission scope change is limited to the scheduled  job

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-15-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)