### PR TITLE
chore(ci): run reporting workflow from merge

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -49,7 +49,7 @@ jobs:
     name: SchemaSpy & ZAP
     needs: [deploy-test]
     secrets: inherit
-    uses: ./.github/workflows/scheduled.yml
+    uses: ./.github/workflows/reporting.yml
 
   deploy-prod:
     name: Deploy (PROD)

--- a/.github/workflows/reporting.yml
+++ b/.github/workflows/reporting.yml
@@ -1,4 +1,4 @@
-name: Scheduled
+name: Reporting
 
 on:
   schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays


### PR DESCRIPTION
## Summary
- add a `reporting` job in `merge.yml` that calls `./.github/workflows/scheduled.yml`
- make `scheduled.yml` reusable by defining `workflow_call: {}`
- keep `deploy-prod` unchanged with `needs: [deploy-test]`

## Why
- wire the existing Scheduled checks (SchemaSpy + ZAP) into the merge pipeline
- avoid introducing an incorrect logical dependency from deploy to reporting

## Scope
- CI workflow wiring only (`.github/workflows/merge.yml`, `.github/workflows/scheduled.yml`)

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-18-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)