### PR TITLE
chore(fix): Remove flaky remote certificate fetch from Docker build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,7 +19,6 @@ RUN set -e; \
     curl --retry 5 \
          --retry-delay 5 \
          --retry-connrefused \
-         --retry-all-errors \
          -fsSL 'https://crt.sh/?d=4256644734' \
          -o "$CERT_FILE" \
       || { \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,19 +8,39 @@ FROM ghcr.io/graalvm/native-image:22.3.3 AS build
 # Policy: do NOT commit the PEM. Approaches supported:
 #  1. Provide the PEM via build arg SECTIGO_R46_PEM (recommended; store content in GitHub/OpenShift secret).
 #  2. Fallback: attempt network fetch from crt.sh (public CT log) if build arg not supplied.
-# If neither succeeds, build continues (native image created) but import step will fail -> non-zero exit to surface issue.
 ARG SECTIGO_R46_PEM=""
+
 RUN set -e; \
   CERT_FILE=/tmp/sectigo-r46-root.pem; \
   if [ -n "$SECTIGO_R46_PEM" ]; then \
-  printf '%b' "$SECTIGO_R46_PEM" > "$CERT_FILE"; \
+    printf '%b' "$SECTIGO_R46_PEM" > "$CERT_FILE"; \
   else \
-  echo "No build arg provided; attempting remote fetch of Sectigo R46 root"; \
-  curl -fsSL 'https://crt.sh/?d=4256644734' -o "$CERT_FILE" || { echo "Remote fetch failed; please supply SECTIGO_R46_PEM."; exit 1; }; \
+    echo "No build arg provided; attempting remote fetch of Sectigo R46 root with retries"; \
+    curl --retry 5 \
+         --retry-delay 5 \
+         --retry-connrefused \
+         --retry-all-errors \
+         -fsSL 'https://crt.sh/?d=4256644734' \
+         -o "$CERT_FILE" \
+      || { \
+        echo "Remote fetch failed after retries; please supply SECTIGO_R46_PEM."; \
+        exit 1; \
+      }; \
   fi; \
-  keytool -importcert -trustcacerts -noprompt -alias sectigo-r46-root -file "$CERT_FILE" \
-  -keystore "$JAVA_HOME/lib/security/cacerts" -storepass changeit; \
-  keytool -list -keystore "$JAVA_HOME/lib/security/cacerts" -storepass changeit | grep -i sectigo || { echo "ERROR: Imported but grep did not match (verify manually)"; exit 1; }; \
+  \
+  keytool -importcert \
+    -trustcacerts \
+    -noprompt \
+    -alias sectigo-r46-root \
+    -file "$CERT_FILE" \
+    -keystore "$JAVA_HOME/lib/security/cacerts" \
+    -storepass changeit; \
+  \
+  keytool -list \
+    -keystore "$JAVA_HOME/lib/security/cacerts" \
+    -storepass changeit \
+    -alias sectigo-r46-root; \
+  \
   rm -f "$CERT_FILE"
 
 # Copy

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,35 +12,50 @@ ARG SECTIGO_R46_PEM=""
 
 RUN set -e; \
   CERT_FILE=/tmp/sectigo-r46-root.pem; \
+  echo "--- Starting Sectigo CA Import ---"; \
   if [ -n "$SECTIGO_R46_PEM" ]; then \
+    echo "Using provided SECTIGO_R46_PEM build argument."; \
     printf '%b' "$SECTIGO_R46_PEM" > "$CERT_FILE"; \
   else \
-    echo "No build arg provided; attempting remote fetch of Sectigo R46 root with retries"; \
-    curl --retry 5 \
+    echo "Attempting remote fetch of Sectigo R46 root..."; \
+    curl -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" \
+         --retry 5 \
          --retry-delay 5 \
          --retry-connrefused \
          -fsSL 'https://crt.sh/?d=4256644734' \
          -o "$CERT_FILE" \
-      || { \
-        echo "Remote fetch failed after retries; please supply SECTIGO_R46_PEM."; \
-        exit 1; \
-      }; \
+      || { echo "ERROR: Curl failed to connect to crt.sh."; exit 1; }; \
+    \
+    echo "Verifying downloaded file format..."; \
+    grep -q "BEGIN CERTIFICATE" "$CERT_FILE" || { \
+      echo "ERROR: Downloaded file is not a valid PEM. crt.sh likely returned an HTML error page. File content:"; \
+      cat "$CERT_FILE"; \
+      exit 1; \
+    }; \
   fi; \
   \
-  keytool -importcert \
-    -trustcacerts \
-    -noprompt \
-    -alias sectigo-r46-root \
-    -file "$CERT_FILE" \
-    -keystore "$JAVA_HOME/lib/security/cacerts" \
-    -storepass changeit; \
+  echo "Checking if alias already exists in trust store..."; \
+  if keytool -list -keystore "$JAVA_HOME/lib/security/cacerts" -storepass changeit -alias sectigo-r46-root >/dev/null 2>&1; then \
+    echo "Alias sectigo-r46-root already exists, skipping import."; \
+  else \
+    echo "Importing certificate..."; \
+    keytool -importcert \
+      -trustcacerts \
+      -noprompt \
+      -alias sectigo-r46-root \
+      -file "$CERT_FILE" \
+      -keystore "$JAVA_HOME/lib/security/cacerts" \
+      -storepass changeit; \
+  fi; \
   \
+  echo "Verifying successful installation..."; \
   keytool -list \
     -keystore "$JAVA_HOME/lib/security/cacerts" \
     -storepass changeit \
-    -alias sectigo-r46-root; \
+    -alias sectigo-r46-root >/dev/null; \
   \
-  rm -f "$CERT_FILE"
+  rm -f "$CERT_FILE"; \
+  echo "--- Sectigo CA Import Successful ---"
 
 # Copy
 WORKDIR /app


### PR DESCRIPTION
* remove runtime curl fallback to crt.sh during image build
* require SECTIGO_R46_PEM build arg instead
* improve truststore verification by checking alias directly with keytool
* reduce intermittent CI/CD build failures caused by external network dependency

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-49-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)