### PR TITLE
fix(#2177): Fixed null business name value

### DIFF
--- a/backend/src/main/java/ca/bc/gov/app/controller/client/ClientSubmissionLimitController.java
+++ b/backend/src/main/java/ca/bc/gov/app/controller/client/ClientSubmissionLimitController.java
@@ -1,14 +1,14 @@
 package ca.bc.gov.app.controller.client;
 
 import ca.bc.gov.app.exception.ValidationException;
+import ca.bc.gov.app.validator.SubmissionValidatorService;
+import io.micrometer.observation.annotation.Observed;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import ca.bc.gov.app.validator.SubmissionValidatorService;
-import io.micrometer.observation.annotation.Observed;
-import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
 @RestController

--- a/backend/src/main/java/ca/bc/gov/app/service/client/ClientSubmissionService.java
+++ b/backend/src/main/java/ca/bc/gov/app/service/client/ClientSubmissionService.java
@@ -427,10 +427,11 @@ public class ClientSubmissionService {
       SubmissionTypeCodeEnum submissionType
   ) {
 
-    log.info("Saving submission from user {} with email {} and name {} with type {}",
+    log.info("Saving submission from user {} with email {} and name {} with type {} and business name {}",
         JwtPrincipalUtil.getUserId(principal),
         JwtPrincipalUtil.getEmail(principal),
         JwtPrincipalUtil.getName(principal),
+        JwtPrincipalUtil.getBusinessName(principal),
         submissionType
     );
 

--- a/backend/src/main/java/ca/bc/gov/app/service/client/ClientSubmissionService.java
+++ b/backend/src/main/java/ca/bc/gov/app/service/client/ClientSubmissionService.java
@@ -431,8 +431,8 @@ public class ClientSubmissionService {
         JwtPrincipalUtil.getUserId(principal),
         JwtPrincipalUtil.getEmail(principal),
         JwtPrincipalUtil.getName(principal),
-        JwtPrincipalUtil.getBusinessName(principal),
-        submissionType
+        submissionType,
+        JwtPrincipalUtil.getBusinessName(principal)
     );
 
     return

--- a/frontend/src/pages/SubmissionReviewPage.vue
+++ b/frontend/src/pages/SubmissionReviewPage.vue
@@ -354,6 +354,9 @@ const renderDuplicatedClientLabel = (duplicatedClientNumbers: []) => {
 };
 
 watch(data, () => {
+  if (data.value?.matchers && 'info' in data.value.matchers) {
+    delete data.value.matchers.info;
+  }
   const submission = data.value;
   const registrationNumber = submission?.business?.registrationNumber;
   const userId = submission.contact?.[0]?.userId

--- a/processor/src/main/java/ca/bc/gov/app/service/client/ClientSubmissionAutoProcessingService.java
+++ b/processor/src/main/java/ca/bc/gov/app/service/client/ClientSubmissionAutoProcessingService.java
@@ -10,9 +10,9 @@ import ca.bc.gov.app.entity.SubmissionTypeCodeEnum;
 import ca.bc.gov.app.repository.SubmissionMatchDetailRepository;
 import ca.bc.gov.app.repository.SubmissionRepository;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,31 +33,37 @@ public class ClientSubmissionAutoProcessingService {
   private final SubmissionMatchDetailRepository submissionMatchDetailRepository;
 
   /**
-   * This method is responsible for marking the submission as approved and sending to the nexty
+   * This method is responsible for marking the submission as approved and sending it to the next
    * step.
    */
-  public Mono<MessagingWrapper<Integer>> approved(MessagingWrapper<List<MatcherResult>> message) {
+  public Mono<MessagingWrapper<Integer>> approved(
+      MessagingWrapper<List<MatcherResult>> message) {
+
     int submissionId =
-        (int) message.parameters()
-            .get(ApplicationConstant.SUBMISSION_ID);
-    return
-        persistData(submissionId, SubmissionTypeCodeEnum.AAC)
-            .doOnNext(id -> log.info("Request {} was approved", id))
-            .flatMap(this::loadFirstOrNew)
-            .doOnNext(entity -> entity.setStatus("Y"))
-            // Preserve existing MATCHING_INFO when approving; clear other matcher entries
-            .doOnNext(entity -> {
-              Map<String, Object> existing = entity.getMatchers() == null
+        (int) message.parameters().get(ApplicationConstant.SUBMISSION_ID);
+
+    return persistData(submissionId, SubmissionTypeCodeEnum.AAC)
+        .doOnNext(id -> log.info("Request {} was approved", id))
+        .flatMap(this::loadFirstOrNew)
+        .doOnNext(entity -> entity.setStatus("Y"))
+        // Preserve existing MATCHING_INFO when approving; clear other matcher entries
+        .doOnNext(entity -> {
+          Map<String, Object> existing =
+              entity.getMatchers() == null
                   ? new HashMap<>()
                   : new HashMap<>(entity.getMatchers());
-              Map<String, Object> keep = new HashMap<>();
-              if (existing.containsKey(ApplicationConstant.MATCHING_INFO)) {
-                keep.put(ApplicationConstant.MATCHING_INFO, existing.get(ApplicationConstant.MATCHING_INFO));
-              }
-              entity.setMatchers(keep);
-            })
-            .flatMap(submissionMatchDetailRepository::save)
-            .thenReturn(new MessagingWrapper<>(submissionId, Map.of()));
+
+          Map<String, Object> keep = new HashMap<>();
+          if (existing.containsKey(ApplicationConstant.MATCHING_INFO)) {
+            keep.put(
+                ApplicationConstant.MATCHING_INFO,
+                existing.get(ApplicationConstant.MATCHING_INFO)
+            );
+          }
+          entity.setMatchers(keep);
+        })
+        .flatMap(submissionMatchDetailRepository::save)
+        .thenReturn(new MessagingWrapper<>(submissionId, Map.of()));
   }
 
   /**
@@ -152,20 +158,23 @@ public class ClientSubmissionAutoProcessingService {
 
   private void updateEntityMatchers(
       SubmissionMatchDetailEntity entity,
-      MessagingWrapper<List<MatcherResult>> message
-  ) {
-    // Preserve existing matcher info coming from the backend (ApplicationConstant.MATCHING_INFO key)
-    Map<String, Object> existing = entity.getMatchers() == null
-        ? new HashMap<>()
-        : new HashMap<>(entity.getMatchers());
+      MessagingWrapper<List<MatcherResult>> message) {
 
-    Map<String, Object> incoming = message
-        .payload()
-        .stream()
-        .filter(MatcherResult::hasMatch)
-        .collect(Collectors.toMap(MatcherResult::fieldName, MatcherResult::value));
+    Map<String, Object> existing =
+        entity.getMatchers() == null
+            ? new HashMap<>()
+            : new HashMap<>(entity.getMatchers());
 
-    // Merge incoming into existing but do NOT overwrite the MATCHING_INFO key
+    Map<String, Object> incoming =
+        message.payload()
+            .stream()
+            .filter(MatcherResult::hasMatch)
+            .collect(Collectors.toMap(
+                MatcherResult::fieldName,
+                MatcherResult::value
+            ));
+
+    // Merge incoming into existing but do NOT overwrite MATCHING_INFO
     incoming.forEach((k, v) -> {
       if (!ApplicationConstant.MATCHING_INFO.equals(k)) {
         existing.put(k, v);

--- a/processor/src/main/java/ca/bc/gov/app/service/client/ClientSubmissionAutoProcessingService.java
+++ b/processor/src/main/java/ca/bc/gov/app/service/client/ClientSubmissionAutoProcessingService.java
@@ -12,6 +12,7 @@ import ca.bc.gov.app.repository.SubmissionRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +45,17 @@ public class ClientSubmissionAutoProcessingService {
             .doOnNext(id -> log.info("Request {} was approved", id))
             .flatMap(this::loadFirstOrNew)
             .doOnNext(entity -> entity.setStatus("Y"))
-            .doOnNext(entity -> entity.setMatchers(Map.of()))
+            // Preserve existing MATCHING_INFO when approving; clear other matcher entries
+            .doOnNext(entity -> {
+              Map<String, Object> existing = entity.getMatchers() == null
+                  ? new HashMap<>()
+                  : new HashMap<>(entity.getMatchers());
+              Map<String, Object> keep = new HashMap<>();
+              if (existing.containsKey(ApplicationConstant.MATCHING_INFO)) {
+                keep.put(ApplicationConstant.MATCHING_INFO, existing.get(ApplicationConstant.MATCHING_INFO));
+              }
+              entity.setMatchers(keep);
+            })
             .flatMap(submissionMatchDetailRepository::save)
             .thenReturn(new MessagingWrapper<>(submissionId, Map.of()));
   }
@@ -143,13 +154,25 @@ public class ClientSubmissionAutoProcessingService {
       SubmissionMatchDetailEntity entity,
       MessagingWrapper<List<MatcherResult>> message
   ) {
-    entity.setMatchers(
-        message
-            .payload()
-            .stream()
-            .filter(MatcherResult::hasMatch)
-            .collect(Collectors.toMap(MatcherResult::fieldName, MatcherResult::value))
-    );
+    // Preserve existing matcher info coming from the backend (ApplicationConstant.MATCHING_INFO key)
+    Map<String, Object> existing = entity.getMatchers() == null
+        ? new HashMap<>()
+        : new HashMap<>(entity.getMatchers());
+
+    Map<String, Object> incoming = message
+        .payload()
+        .stream()
+        .filter(MatcherResult::hasMatch)
+        .collect(Collectors.toMap(MatcherResult::fieldName, MatcherResult::value));
+
+    // Merge incoming into existing but do NOT overwrite the MATCHING_INFO key
+    incoming.forEach((k, v) -> {
+      if (!ApplicationConstant.MATCHING_INFO.equals(k)) {
+        existing.put(k, v);
+      }
+    });
+
+    entity.setMatchers(existing);
   }
 
   private MessagingWrapper<Integer> createMessagingWrapper(SubmissionMatchDetailEntity entity,

--- a/processor/src/test/java/ca/bc/gov/app/service/client/ClientSubmissionAutoProcessingServiceIntegrationTest.java
+++ b/processor/src/test/java/ca/bc/gov/app/service/client/ClientSubmissionAutoProcessingServiceIntegrationTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
-
 import ca.bc.gov.app.ApplicationConstant;
 import ca.bc.gov.app.dto.MatcherResult;
 import ca.bc.gov.app.dto.MessagingWrapper;
@@ -16,7 +15,9 @@ import ca.bc.gov.app.entity.SubmissionMatchDetailEntity;
 import ca.bc.gov.app.extensions.AbstractTestContainer;
 import ca.bc.gov.app.repository.SubmissionMatchDetailRepository;
 import ca.bc.gov.app.repository.SubmissionRepository;
+import io.r2dbc.postgresql.codec.Json;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +72,61 @@ class ClientSubmissionAutoProcessingServiceIntegrationTest extends AbstractTestC
         .untilAsserted(() ->
             verify(submissionRepository, atLeastOnce()).save(any(SubmissionEntity.class))
         );
+  }
+
+  @Test
+  @DisplayName("approved preserves matching info")
+  void shouldPreserveMatchingInfoOnApprove() {
+
+    // Use an existing seeded submission (id=368 has a matching_detail row with {"info":{}})
+    final int submissionId = 368;
+
+    SubmissionMatchDetailEntity seed = SubmissionMatchDetailEntity.builder()
+        .submissionId(submissionId)
+        .createdBy("test")
+        .updatedAt(LocalDateTime.now())
+        .matchingField(Json.of(
+            "{\"info\":{\"name\":\"John Doe\",\"email\":\"john.doe@gov.bc.ca\"},"
+                + "\"contact\":\"00190928\"}"
+        ))
+        .build();
+
+    // Upsert: if a matching detail already exists for the submission, update it; otherwise insert.
+    submissionMatchDetailRepository
+        .findBySubmissionId(submissionId)
+        .flatMap(existing -> {
+          SubmissionMatchDetailEntity updated = existing
+              .withMatchingField(seed.getMatchingField())
+              .withUpdatedAt(LocalDateTime.now())
+              .withCreatedBy(existing.getCreatedBy() == null ? "test" : existing.getCreatedBy());
+          return submissionMatchDetailRepository.save(updated);
+        })
+        .switchIfEmpty(submissionMatchDetailRepository.save(seed))
+        .as(StepVerifier::create)
+        .assertNext(saved -> Assertions.assertEquals(submissionId, saved.getSubmissionId()))
+        .verifyComplete();
+
+    service
+        .approved(new MessagingWrapper<>(
+            new ArrayList<>(),
+            Map.of(ApplicationConstant.SUBMISSION_ID, submissionId)
+        ))
+        .as(StepVerifier::create)
+        .assertNext(message ->
+            Assertions.assertEquals(Integer.valueOf(submissionId), message.payload())
+        )
+        .verifyComplete();
+
+    submissionMatchDetailRepository
+        .findBySubmissionId(submissionId)
+        .as(StepVerifier::create)
+        .assertNext(entity -> {
+          AssertionsForInterfaceTypes.assertThat(entity.getMatchers())
+              .isNotNull()
+              .containsKey(ApplicationConstant.MATCHING_INFO)
+              .hasSize(1);
+        })
+        .verifyComplete();
   }
 
   @Test

--- a/processor/src/test/java/ca/bc/gov/app/service/client/ClientSubmissionAutoProcessingServiceIntegrationTest.java
+++ b/processor/src/test/java/ca/bc/gov/app/service/client/ClientSubmissionAutoProcessingServiceIntegrationTest.java
@@ -16,9 +16,7 @@ import ca.bc.gov.app.entity.SubmissionMatchDetailEntity;
 import ca.bc.gov.app.extensions.AbstractTestContainer;
 import ca.bc.gov.app.repository.SubmissionMatchDetailRepository;
 import ca.bc.gov.app.repository.SubmissionRepository;
-import io.r2dbc.postgresql.codec.Json;
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -73,49 +71,6 @@ class ClientSubmissionAutoProcessingServiceIntegrationTest extends AbstractTestC
         .untilAsserted(() ->
             verify(submissionRepository, atLeastOnce()).save(any(SubmissionEntity.class))
         );
-  }
-
-  @Test
-  @DisplayName("approved preserves matching info")
-  void shouldPreserveMatchingInfoOnApprove() {
-
-    SubmissionMatchDetailEntity seed = SubmissionMatchDetailEntity.builder()
-        .submissionId(10)
-        .createdBy("test")
-        .updatedAt(LocalDateTime.now())
-        .matchingField(Json.of(
-            "{\"info\":{\"name\":\"Maria Martinez\",\"email\":\"maria.martinez@gov.bc.ca\"},"
-                + "\"contact\":\"00190928\"}"
-        ))
-        .build();
-
-    submissionMatchDetailRepository
-        .save(seed)
-        .as(StepVerifier::create)
-        .assertNext(saved -> Assertions.assertEquals(10, saved.getSubmissionId()))
-        .verifyComplete();
-
-    service
-        .approved(new MessagingWrapper<>(
-            new ArrayList<>(),
-            Map.of(ApplicationConstant.SUBMISSION_ID, 10)
-        ))
-        .as(StepVerifier::create)
-        .assertNext(message ->
-            Assertions.assertEquals(Integer.valueOf(10), message.payload())
-        )
-        .verifyComplete();
-
-    submissionMatchDetailRepository
-        .findBySubmissionId(10)
-        .as(StepVerifier::create)
-        .assertNext(entity -> {
-          AssertionsForInterfaceTypes.assertThat(entity.getMatchers())
-              .isNotNull()
-              .containsKey(ApplicationConstant.MATCHING_INFO)
-              .hasSize(1);
-        })
-        .verifyComplete();
   }
 
   @Test

--- a/processor/src/test/java/ca/bc/gov/app/service/client/ClientSubmissionAutoProcessingServiceIntegrationTest.java
+++ b/processor/src/test/java/ca/bc/gov/app/service/client/ClientSubmissionAutoProcessingServiceIntegrationTest.java
@@ -16,7 +16,9 @@ import ca.bc.gov.app.entity.SubmissionMatchDetailEntity;
 import ca.bc.gov.app.extensions.AbstractTestContainer;
 import ca.bc.gov.app.repository.SubmissionMatchDetailRepository;
 import ca.bc.gov.app.repository.SubmissionRepository;
+import io.r2dbc.postgresql.codec.Json;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +73,49 @@ class ClientSubmissionAutoProcessingServiceIntegrationTest extends AbstractTestC
         .untilAsserted(() ->
             verify(submissionRepository, atLeastOnce()).save(any(SubmissionEntity.class))
         );
+  }
+
+  @Test
+  @DisplayName("approved preserves matching info")
+  void shouldPreserveMatchingInfoOnApprove() {
+
+    SubmissionMatchDetailEntity seed = SubmissionMatchDetailEntity.builder()
+        .submissionId(10)
+        .createdBy("test")
+        .updatedAt(LocalDateTime.now())
+        .matchingField(Json.of(
+            "{\"info\":{\"name\":\"Maria Martinez\",\"email\":\"maria.martinez@gov.bc.ca\"},"
+                + "\"contact\":\"00190928\"}"
+        ))
+        .build();
+
+    submissionMatchDetailRepository
+        .save(seed)
+        .as(StepVerifier::create)
+        .assertNext(saved -> Assertions.assertEquals(10, saved.getSubmissionId()))
+        .verifyComplete();
+
+    service
+        .approved(new MessagingWrapper<>(
+            new ArrayList<>(),
+            Map.of(ApplicationConstant.SUBMISSION_ID, 10)
+        ))
+        .as(StepVerifier::create)
+        .assertNext(message ->
+            Assertions.assertEquals(Integer.valueOf(10), message.payload())
+        )
+        .verifyComplete();
+
+    submissionMatchDetailRepository
+        .findBySubmissionId(10)
+        .as(StepVerifier::create)
+        .assertNext(entity -> {
+          AssertionsForInterfaceTypes.assertThat(entity.getMatchers())
+              .isNotNull()
+              .containsKey(ApplicationConstant.MATCHING_INFO)
+              .hasSize(1);
+        })
+        .verifyComplete();
   }
 
   @Test


### PR DESCRIPTION
The issue was that the backend stored important submitter metadata under the MATCHING_INFO key (the "info" JSON) in nrfc.submission_matching_detail, but the processor code replaced the entire matchers map when it saved updates—so the backend info entry was being wiped out and replaced by other keys (e.g. a contact list). I updated ClientSubmissionAutoProcessingService.java to preserve that backend-provided MATCHING_INFO: during review updates we now merge incoming matcher entries into the existing map but explicitly do not overwrite the MATCHING_INFO key, and during approval we keep only the MATCHING_INFO entry (if present) while clearing other matcher keys. As a result, other matcher fields may still be added or replaced as before, but the original info metadata from the backend will no longer be lost.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-30-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)