### PR TITLE
feat(fe): BC Registry tab - Added message as per Todd's request

### DIFF
--- a/frontend/src/pages/client-details/BcRegistryView.vue
+++ b/frontend/src/pages/client-details/BcRegistryView.vue
@@ -74,13 +74,22 @@ const partyAddress = (party: BcRegistryParty): string => {
     <div class="tab-header">
       <div class="flex-column-0_25rem padding-left-1rem">
         <h3>BC Registry information</h3>
-        <p class="body-compact-01">
-          <br />Some information such as addresses, partners, dates, etc., may not be available. Please verify the details with BC Registries.
-        </p>
       </div>
     </div>
 
     <div class="tab-panel tab-panel--populated">
+      <cds-inline-notification
+        data-text="Client information"
+        v-shadow="2"
+        id="bcRegistryDownNotification"
+        low-contrast="true"
+        open="true"
+        kind="warning"
+        hide-close-button="true">
+        <span class="body-compact-01">
+          Some information such as addresses, partners, dates, etc., may not be available. Please verify the details with BC Registries.
+        </span>
+      </cds-inline-notification>
 
       <!-- Business information accordion -->
       <cds-accordion id="bc-business-information">

--- a/frontend/src/pages/client-details/BcRegistryView.vue
+++ b/frontend/src/pages/client-details/BcRegistryView.vue
@@ -74,9 +74,9 @@ const partyAddress = (party: BcRegistryParty): string => {
     <div class="tab-header">
       <div class="flex-column-0_25rem padding-left-1rem">
         <h3>BC Registry information</h3>
-        <span class="body-compact-01">
-          <br />Some information, such as addresses, partners, dates, etc., may not be available. Please verify details directly with BC Registries.
-        </span>
+        <p class="body-compact-01">
+          Some information, such as addresses, partners, dates, etc., may not be available. Please verify details directly with BC Registries
+        </p>
       </div>
     </div>
 

--- a/frontend/src/pages/client-details/BcRegistryView.vue
+++ b/frontend/src/pages/client-details/BcRegistryView.vue
@@ -75,7 +75,7 @@ const partyAddress = (party: BcRegistryParty): string => {
       <div class="flex-column-0_25rem padding-left-1rem">
         <h3>BC Registry information</h3>
         <p class="body-compact-01">
-          Some information, such as addresses, partners, dates, etc., may not be available. Please verify details directly with BC Registries
+          <br />Some information such as addresses, partners, dates, etc., may not be available. Please verify the details with BC Registries.
         </p>
       </div>
     </div>

--- a/frontend/src/pages/client-details/BcRegistryView.vue
+++ b/frontend/src/pages/client-details/BcRegistryView.vue
@@ -61,7 +61,7 @@ const partyAddress = (party: BcRegistryParty): string => {
       <div></div>
     </div>
   </div>
-  
+
   <div
     class="tab-panel tab-panel--empty"
     v-else-if="error?.message || !bcRegistryInfo"
@@ -71,8 +71,13 @@ const partyAddress = (party: BcRegistryParty): string => {
 
   <!-- Populated state -->
   <div v-else>
-    <div class="tab-header space-between">
-      <h3 class="padding-left-1rem">BC Registry information</h3>
+    <div class="tab-header">
+      <div class="flex-column-0_25rem padding-left-1rem">
+        <h3>BC Registry information</h3>
+        <span class="body-compact-01">
+          <br />Some information, such as addresses, partners, dates, etc., may not be available. Please verify details directly with BC Registries.
+        </span>
+      </div>
     </div>
 
     <div class="tab-panel tab-panel--populated">


### PR DESCRIPTION
# Description

Adds a short explanatory message to informing users that some BC Registry fields (addresses, partners, dates, etc.) may be unavailable and advising them to verify details directly with BC Registries — improves UX by setting expectations when data is blank.

Fixes # (https://github.com/bcgov/nr-forest-client/issues/2201)

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-2-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)