### PR TITLE
chore(fe): fix CWE-79 vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10451,9 +10451,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -118,7 +118,7 @@
     "wiremock": "^3.13.2"
   },
   "overrides": {
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.9",
     "uuid": "^14.0.0",
     "picomatch@^4.0.0": "^4.0.4",
     "flatted": "^3.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -118,7 +118,7 @@
     "wiremock": "^3.13.2"
   },
   "overrides": {
-    "dompurify": "^3.4.9",
+    "dompurify": "^3.4.10",
     "uuid": "^14.0.0",
     "picomatch@^4.0.0": "^4.0.4",
     "flatted": "^3.4.2",


### PR DESCRIPTION
## Description

This pull request addresses a high-severity prototype pollution XSS vulnerability in the `dompurify` package.

## Security Issue

- **CVE ID:** CVE-2026-41238
- **Severity:** High
- **Vulnerability Type:** Prototype Pollution leading to XSS bypass via `CUSTOM_ELEMENT_HANDLING`
- **Affected Package:** dompurify (transitive dependency)
- **Current Version:** 3.4.0
- **Fixed Version:** 3.4.10

## Changes

Updated the `dompurify` package version from 3.4.0 to 3.4.10 via the package.json overrides configuration to ensure the security patch is applied across the dependency tree.

### Files Changed
- package.json — updated override for dompurify package
- package-lock.json — automatically updated by npm install

## Testing

- Ran `npm install` to verify dependency resolution
- Confirmed package-lock.json was updated with the patched version

## Closing Issue

Closes #249

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-25-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)