### PR TITLE
fix(fe): fixed CVE-2026-53632 vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3993,21 +3993,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4016,9 +4016,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -137,7 +137,8 @@
     "js-yaml": "4.2.0",
     "fast-uri": "4.0.0",
     "@babel/plugin-transform-modules-systemjs": "^8.0.0",
-    "js-cookie": "^3.0.7"
+    "js-cookie": "^3.0.7",
+    "launch-editor": "^2.14.1"
   },
   "nyc": {
     "check-coverage": true,


### PR DESCRIPTION
## Description

This pull request addresses an NTLMv2 Hash Disclosure vulnerability in the `launch-editor` package, which is used by development server tooling (e.g. Vite) to open files in a local editor. On Windows, the package fails to restrict UNC paths, which can cause the victim's NTLMv2 hash to be leaked to an attacker-controlled SMB server.

## Security Issue

- **GHSA ID:** GHSA-v6wh-96g9-6wx3
- **CVE ID:** CVE-2026-53632
- **Severity:** Medium
- **Vulnerability Type:** NTLMv2 Hash Disclosure via UNC Path Handling (Windows only)
- **Affected Package:** launch-editor
- **Affected Versions:** <= 2.14.0
- **Fixed Version:** 2.14.1

## Changes

Updated the `launch-editor` package version to ^2.14.1 via the package.json overrides configuration to ensure the security patch is applied across the dependency tree.

### Files Changed
- frontend/package.json — added override for launch-editor package
- frontend/package-lock.json — automatically updated by npm install

## Testing

- Ran `npm install` to verify dependency resolution
- Confirmed package-lock.json was updated with the patched version

## Closing Issue

Closes [246](https://github.com/bcgov/nr-forest-client/security/dependabot/246)

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-32-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)