### PR TITLE
chore(fe): fixed nth-check vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8544,14 +8544,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/css-select/node_modules/nth-check": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "~1.0.0"
-      }
-    },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
       "dev": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -139,7 +139,7 @@
     "fast-uri": "4.1.0",
     "@babel/plugin-transform-modules-systemjs": "^8.0.0",
     "js-cookie": "^3.0.7",
-    "nth-check": "^2.0.1"
+    "nth-check@<2.1.1": "2.1.1"
   },
   "nyc": {
     "check-coverage": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -138,7 +138,8 @@
     "js-yaml": "5.2.0",
     "fast-uri": "4.1.0",
     "@babel/plugin-transform-modules-systemjs": "^8.0.0",
-    "js-cookie": "^3.0.7"
+    "js-cookie": "^3.0.7",
+    "nth-check": "^2.0.1"
   },
   "nyc": {
     "check-coverage": true,


### PR DESCRIPTION
## Task Summary

Remediate a known vulnerability in the transitive `nth-check` dependency (< 2.0.1) by forcing all references in the frontend to resolve to a patched version via an npm override.

---

## Background

`nth-check` versions below `2.0.1` contain a known vulnerability. The frontend was pulling in a vulnerable version transitively through the following dependency chain:

```
vue-svg-loader → svg-to-vue → svgo@1.3.2 → css-select@2.1.0 → nth-check@1.0.2
```

Since `nth-check` is not a direct dependency, it can't be bumped directly — it needs to be forced via an npm `overrides` entry so every transitive consumer resolves to the patched version.

---

## Task Details

### 1. `frontend/package.json`

Add `nth-check` to the `overrides` section, pinned to the patched range:

```json
"overrides": {
  "nth-check": "^2.0.1"
}
```

This forces all transitive dependents (including `vue-svg-loader` → `svg-to-vue` → `svgo` → `css-select`) to resolve `nth-check` to `2.1.1` instead of the vulnerable `1.0.2`.

### 2. `frontend/package-lock.json`

Regenerate the lockfile so the override is reflected and `nth-check@2.1.1` is resolved throughout the dependency tree.

### 3. Verification

- Run `npm ls nth-check` and confirm only `2.1.1` (or later within the `^2.0.1` range) appears — no `1.0.2` entries remain.
- Run the frontend build and existing test suite to confirm the forced version doesn't break `vue-svg-loader`/`svgo`/`css-select` behavior (e.g., SVG loading still works as expected).
- Re-run the dependency vulnerability scan to confirm the `nth-check` finding is resolved.

---

## Acceptance Criteria

- [ ] `nth-check` is overridden to `^2.0.1` in `frontend/package.json`
- [ ] `npm ls nth-check` shows only the patched version across the dependency tree
- [ ] `package-lock.json` is regenerated and consistent with the override
- [ ] Frontend build and test suite pass with the override in place
- [ ] Vulnerability scan no longer flags `nth-check`

---

## Notes

- This is a dependency-only security fix — no application code or business logic changes are included.
- Reference: PR [#2324](https://github.com/bcgov/nr-forest-client/pull/2324) — `chore(fe): fixed nth-check vulnerability`.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-24-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)