### PR TITLE
fix(ci): added missing logout URLs for external users

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -46,7 +46,6 @@ jobs:
         window.localStorage.setItem(\"VITE_FEATURE_FLAGS\",'{}');
         window.localStorage.setItem(\"VITE_LOGOUT_BCSC_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
         window.localStorage.setItem(\"VITE_LOGOUT_BCEIDBUSINESS_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
-        window.localStorage.setItem(\"VITE_LOGOUT_IDIR_URL\",'https://forestclient-test.apps.silver.devops.gov.bc.ca/');
 
   reporting:
     name: SchemaSpy & ZAP
@@ -77,7 +76,6 @@ jobs:
         window.localStorage.setItem(\"VITE_FEATURE_FLAGS\",'{}');
         window.localStorage.setItem(\"VITE_LOGOUT_BCSC_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
         window.localStorage.setItem(\"VITE_LOGOUT_BCEIDBUSINESS_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
-        window.localStorage.setItem(\"VITE_LOGOUT_IDIR_URL\",'https://forestclient.nrs.gov.bc.ca/');
 
   images-prod:
     name: Promote images to PROD

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -44,6 +44,9 @@ jobs:
             component: backend
       configmap-frontend: |-
         window.localStorage.setItem(\"VITE_FEATURE_FLAGS\",'{}');
+        window.localStorage.setItem(\"VITE_LOGOUT_BCSC_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
+        window.localStorage.setItem(\"VITE_LOGOUT_BCEIDBUSINESS_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
+        window.localStorage.setItem(\"VITE_LOGOUT_IDIR_URL\",'https://forestclient-test.apps.silver.devops.gov.bc.ca/');
 
   reporting:
     name: SchemaSpy & ZAP
@@ -72,6 +75,9 @@ jobs:
             component: backend
       configmap-frontend: |-
         window.localStorage.setItem(\"VITE_FEATURE_FLAGS\",'{}');
+        window.localStorage.setItem(\"VITE_LOGOUT_BCSC_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
+        window.localStorage.setItem(\"VITE_LOGOUT_BCEIDBUSINESS_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
+        window.localStorage.setItem(\"VITE_LOGOUT_IDIR_URL\",'https://forestclient.nrs.gov.bc.ca/');
 
   images-prod:
     name: Promote images to PROD

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -46,6 +46,7 @@ jobs:
         window.localStorage.setItem(\"VITE_FEATURE_FLAGS\",'{}');
         window.localStorage.setItem(\"VITE_LOGOUT_BCSC_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
         window.localStorage.setItem(\"VITE_LOGOUT_BCEIDBUSINESS_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
+        window.localStorage.setItem(\"VITE_LOGOUT_IDIR_URL\",'https://forestclient-test.apps.silver.devops.gov.bc.ca/');
 
   reporting:
     name: SchemaSpy & ZAP
@@ -76,6 +77,7 @@ jobs:
         window.localStorage.setItem(\"VITE_FEATURE_FLAGS\",'{}');
         window.localStorage.setItem(\"VITE_LOGOUT_BCSC_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
         window.localStorage.setItem(\"VITE_LOGOUT_BCEIDBUSINESS_URL\",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
+        window.localStorage.setItem(\"VITE_LOGOUT_IDIR_URL\",'https://forestclient.nrs.gov.bc.ca/');
 
   images-prod:
     name: Promote images to PROD


### PR DESCRIPTION
## Task Summary

Add the missing external-user logout URL environment variables to the deployment configmap in the merge workflow, so BCSC, BCeID Business, and IDIR users are redirected to the correct logout landing page after signing out.

---

## Background

The frontend reads logout redirect URLs from `VITE_LOGOUT_*` environment variables, injected at deploy time via `window.localStorage.setItem(...)` calls in the frontend configmap block of `.github/workflows/merge.yml`. The configmap was missing entries for BCSC, BCeID Business, and IDIR users, so those user types had no configured logout redirect target in the affected environments.

---

## Task Details

### 1. `.github/workflows/merge.yml`

Add the following `localStorage` entries to the frontend configmap for **both** the Test and Prod deployment jobs (alongside the existing `VITE_FEATURE_FLAGS` entry):

```yaml
window.localStorage.setItem("VITE_LOGOUT_BCSC_URL",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
window.localStorage.setItem("VITE_LOGOUT_BCEIDBUSINESS_URL",'https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number');
window.localStorage.setItem("VITE_LOGOUT_IDIR_URL",'<environment-specific URL>');
```

- **BCSC** and **BCeID Business** should point to the same client-number info page in both environments: `https://www2.gov.bc.ca/gov/content/industry/natural-resource-use/client-number`.
- **IDIR** should point to an environment-specific URL:
  - Test: `https://forestclient-test.apps.silver.devops.gov.bc.ca/`
  - Prod: `https://forestclient.nrs.gov.bc.ca/`

### 2. Verification

- Deploy to Test and confirm that logging out as a BCSC, BCeID Business, and IDIR user each redirects to the expected URL.
- Confirm no existing feature flag or configmap behaviour is affected by the added lines.
- Repeat the check after promotion to Prod.

---

## Acceptance Criteria

- [ ] `VITE_LOGOUT_BCSC_URL` is set correctly in both Test and Prod configmaps
- [ ] `VITE_LOGOUT_BCEIDBUSINESS_URL` is set correctly in both Test and Prod configmaps
- [ ] `VITE_LOGOUT_IDIR_URL` is set correctly per environment (Test vs Prod URLs differ)
- [ ] Logging out as each of the three external user types redirects to the correct destination in Test
- [ ] Same behaviour confirmed in Prod after promotion

---

## Notes

- Single-file change: `.github/workflows/merge.yml` (+6 lines, two locations — Test and Prod jobs).
- No application code changes — this is purely a CI/deployment configuration fix.
- Reference: PR [[#2325](https://github.com/bcgov/nr-forest-client/pull/2325)](https://github.com/bcgov/nr-forest-client/pull/2325) — `fix(ci): added missing logout URLs for external users`.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-25-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)