### PR TITLE
fix(be): improved code to avoid duplication of clients

### DIFF
--- a/processor/src/main/java/ca/bc/gov/app/service/legacy/LegacyAbstractPersistenceService.java
+++ b/processor/src/main/java/ca/bc/gov/app/service/legacy/LegacyAbstractPersistenceService.java
@@ -111,9 +111,27 @@ public abstract class LegacyAbstractPersistenceService {
 
   /**
    * Creates a client if does not exist on oracle and get back the client number.
+   * If a client number already exists for this submission, creation is skipped to
+   * prevent duplicate client creation (e.g. during processor restarts/deployments).
    */
   public Mono<MessagingWrapper<Integer>> createForestClient(
       MessagingWrapper<ForestClientDto> message) {
+
+    String existingClientNumber = message.payload().clientNumber();
+
+    if (StringUtils.isNotBlank(existingClientNumber)) {
+      log.info("Client {} already exists for submission {}, skipping creation",
+          existingClientNumber,
+          message.parameters().get(ApplicationConstant.SUBMISSION_ID)
+      );
+      return Mono.just(
+          new MessagingWrapper<>(
+              (Integer) message.parameters().get(ApplicationConstant.SUBMISSION_ID),
+              message.parameters()
+          )
+              .withParameter(ApplicationConstant.FOREST_CLIENT_NUMBER, existingClientNumber)
+      );
+    }
 
     log.info("Creating Forest Client {} {}",
         message.parameters().get(ApplicationConstant.FOREST_CLIENT_NAME),

--- a/processor/src/test/java/ca/bc/gov/app/service/legacy/LegacyAbstractPersistenceServiceTest.java
+++ b/processor/src/test/java/ca/bc/gov/app/service/legacy/LegacyAbstractPersistenceServiceTest.java
@@ -1,7 +1,6 @@
 package ca.bc.gov.app.service.legacy;
 
 
-import static ca.bc.gov.app.TestConstants.CLIENT_ENTITY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -11,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import ca.bc.gov.app.ApplicationConstant;
 import ca.bc.gov.app.dto.MessagingWrapper;
+import ca.bc.gov.app.dto.legacy.ForestClientDto;
 import ca.bc.gov.app.entity.SubmissionContactEntity;
 import ca.bc.gov.app.entity.SubmissionDetailEntity;
 import ca.bc.gov.app.entity.SubmissionLocationContactEntity;
@@ -353,16 +353,20 @@ class LegacyAbstractPersistenceServiceTest {
     when(legacyService.createClient(any()))
         .thenReturn(Mono.just("00000000"));
 
+    ForestClientDto newClient = new ForestClientDto(
+        null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null
+    );
+
     service
         .createForestClient(
             new MessagingWrapper<>(
-                CLIENT_ENTITY,
+                newClient,
                 Map.of(
                     ApplicationConstant.SUBMISSION_ID, 2,
                     ApplicationConstant.CREATED_BY, ApplicationConstant.PROCESSOR_USER_NAME,
                     ApplicationConstant.UPDATED_BY, ApplicationConstant.PROCESSOR_USER_NAME,
                     ApplicationConstant.CLIENT_TYPE_CODE, "C",
-                    ApplicationConstant.FOREST_CLIENT_NUMBER, "00000000",
                     ApplicationConstant.FOREST_CLIENT_NAME, "CHAMPAGNE SUPERNOVA"
                 )
             )
@@ -379,6 +383,45 @@ class LegacyAbstractPersistenceServiceTest {
               .isNotNull()
               .isInstanceOf(String.class)
               .isEqualTo("00000000");
+        })
+        .verifyComplete();
+
+  }
+
+  @Test
+  @DisplayName("skip client creation when client number already exists")
+  void shouldSkipClientCreationWhenClientNumberExists() {
+
+    ForestClientDto existingClient = new ForestClientDto(
+        null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null
+    ).withClientNumber("00001000");
+
+    service
+        .createForestClient(
+            new MessagingWrapper<>(
+                existingClient,
+                Map.of(
+                    ApplicationConstant.SUBMISSION_ID, 2,
+                    ApplicationConstant.CREATED_BY, ApplicationConstant.PROCESSOR_USER_NAME,
+                    ApplicationConstant.UPDATED_BY, ApplicationConstant.PROCESSOR_USER_NAME,
+                    ApplicationConstant.CLIENT_TYPE_CODE, "C",
+                    ApplicationConstant.FOREST_CLIENT_NAME, "CHAMPAGNE SUPERNOVA"
+                )
+            )
+        )
+        .as(StepVerifier::create)
+        .assertNext(message -> {
+          assertThat(message)
+              .as("message")
+              .isNotNull()
+              .hasFieldOrPropertyWithValue("payload", 2);
+
+          assertThat(message.parameters().get(ApplicationConstant.FOREST_CLIENT_NUMBER))
+              .as("forest client number")
+              .isNotNull()
+              .isInstanceOf(String.class)
+              .isEqualTo("00001000");
         })
         .verifyComplete();
 

--- a/processor/src/test/java/ca/bc/gov/app/service/legacy/LegacyRegisteredSPPersistenceServiceTest.java
+++ b/processor/src/test/java/ca/bc/gov/app/service/legacy/LegacyRegisteredSPPersistenceServiceTest.java
@@ -292,20 +292,20 @@ class LegacyRegisteredSPPersistenceServiceTest {
     when(legacyService.createClient(any()))
         .thenReturn(Mono.just("00000000"));
 
+    ForestClientDto newClient = new ForestClientDto(
+        null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null
+    ).withClientTypeCode("I").withClientIdTypeCode("BCRE");
+
     service
         .createForestClient(
             new MessagingWrapper<>(
-                TestConstants
-                    .CLIENT_ENTITY
-                    .withClientTypeCode("I")
-                    .withClientIdTypeCode("BCRE")
-                ,
+                newClient,
                 Map.of(
                     ApplicationConstant.SUBMISSION_ID, 2,
                     ApplicationConstant.CREATED_BY, ApplicationConstant.PROCESSOR_USER_NAME,
                     ApplicationConstant.UPDATED_BY, ApplicationConstant.PROCESSOR_USER_NAME,
                     ApplicationConstant.CLIENT_TYPE_CODE, "RSP",
-                    ApplicationConstant.FOREST_CLIENT_NUMBER, "00000000",
                     ApplicationConstant.FOREST_CLIENT_NAME, "CHAMPAGNE SUPERNOVA",
                     ApplicationConstant.CLIENT_SUBMITTER_NAME, "Jhon Snow"
                 )
@@ -335,13 +335,15 @@ class LegacyRegisteredSPPersistenceServiceTest {
       MessagingWrapper<ForestClientDto> wrapper
   ) {
 
+    String expectedClientNumber = "00100000";
+
     SubmissionDetailEntity detailEntity = SubmissionDetailEntity
         .builder()
         .submissionId(2)
         .registrationNumber("XX0000000")
         .organizationName("Sample test")
         .clientTypeCode("RSP")
-        .clientNumber(wrapper.payload().clientNumber())
+        .clientNumber(expectedClientNumber)
         .build();
 
     when(submissionDetailRepository.findBySubmissionId(any()))
@@ -349,9 +351,9 @@ class LegacyRegisteredSPPersistenceServiceTest {
     when(submissionDetailRepository.save(any()))
         .thenReturn(Mono.just(detailEntity));
     when(legacyService.createDoingBusinessAs(any(), any(), any(), any()))
-        .thenReturn(Mono.just(wrapper.payload().clientNumber()));
+        .thenReturn(Mono.just(expectedClientNumber));
     when(legacyService.createClient(any()))
-        .thenReturn(Mono.just(wrapper.payload().clientNumber()));
+        .thenReturn(Mono.just(expectedClientNumber));
 
     service
         .createForestClient(wrapper)
@@ -366,7 +368,7 @@ class LegacyRegisteredSPPersistenceServiceTest {
               .as("forest client number")
               .isNotNull()
               .isInstanceOf(String.class)
-              .isEqualTo(wrapper.payload().clientNumber());
+              .isEqualTo(expectedClientNumber);
         })
         .verifyComplete();
 
@@ -589,7 +591,7 @@ class LegacyRegisteredSPPersistenceServiceTest {
 
   private static Stream<Arguments> generateDoingBusinessAs() {
     Integer submissionId = 9999;
-    String clientNumber = "00100000";
+    String clientNumber = null;
 
     return Stream.of(
         Arguments.of(


### PR DESCRIPTION
## Problem

In production, the client processor occasionally creates the **same client twice** for a single submission. This surfaces during processor restarts/deployments: if `createForestClient` gets invoked again for a submission whose client was already created (but, e.g., the processor was killed/redeployed before the result was fully acknowledged/persisted), it has no way to know a client number was already assigned, so it calls Oracle again and a duplicate client record is created.

## Fix

`LegacyAbstractPersistenceService#createForestClient` now checks whether the incoming message already carries a `clientNumber`. If one is present, client creation is skipped entirely — the method logs that the client already exists for that submission and short-circuits straight to returning a `MessagingWrapper` populated with the existing `FOREST_CLIENT_NUMBER`, instead of calling Oracle to create a new one.

This makes the operation idempotent with respect to retries/redeployments: re-processing a submission that already has a client number no longer results in a second client being created.

## Testing

- Added `shouldSkipClientCreationWhenClientNumberExists` in `LegacyAbstractPersistenceServiceTest`, asserting that when `clientNumber` is already set on the payload, no new client is created and the existing number is passed through in the result.
- Updated existing tests in `LegacyAbstractPersistenceServiceTest` and `LegacyRegisteredSPPersistenceServiceTest` that were implicitly relying on `clientNumber` echoing through, to use explicit expected values instead (so they don't mask the new short-circuit behavior).

## Impact

Prevents duplicate client creation in Oracle when the processor reprocesses a submission after a restart/deployment — directly addresses the production incident where a client was created twice during a deployment.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-40-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)