### PR TITLE
fix(#2374): Add a validation in both BE and FE when there is no association between the legal type and client type

### DIFF
--- a/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
+++ b/frontend/src/pages/bceidform/BusinessInformationWizardStep.vue
@@ -157,12 +157,6 @@ watch([autoCompleteResult], () => {
     formData.value.businessInformation.clientType = retrieveClientType(
       autoCompleteResult.value.legalType
     );
-
-    if (!formData.value.businessInformation.clientType) {
-      toggleErrorMessages(null, null, null, null, true);
-      return;
-    };
-    
     showAutoCompleteInfo.value = false;
 
     if (formData.value.businessInformation.clientType === 'RSP') {

--- a/frontend/src/pages/staffform/BcRegisteredClientInformationWizardStep.vue
+++ b/frontend/src/pages/staffform/BcRegisteredClientInformationWizardStep.vue
@@ -63,24 +63,6 @@ const errorBus = useEventBus<ValidationMessageType[]>(
 const formData = ref<FormDataDto>(props.data);
 const showUnsupportedLegalTypeError = ref<boolean>(false); 
 
-const toggleErrorMessages = (
-  unsupportedLegalType: boolean | null = null,
-) => {
-  showUnsupportedLegalTypeError.value = unsupportedLegalType ?? false;
-
-  if (unsupportedLegalType) {
-    progressIndicatorBus.emit({ kind: "disabled", value: true });
-    exitBus.emit({
-      unsupportedLegalType
-    });
-  } else {
-    progressIndicatorBus.emit({ kind: "disabled", value: false });
-    exitBus.emit({
-      unsupportedLegalType: false
-    });
-  }
-};
-
 watch(
   () => formData.value,
   () => emit("update:data", formData.value)
@@ -164,16 +146,29 @@ watch([autoCompleteResult], () => {
     );
     formData.value.businessInformation.businessType = getEnumKeyByEnumValue(BusinessTypeEnum, BusinessTypeEnum.R);
 
-    if (!formData.value.businessInformation.clientType) {
-      toggleErrorMessages(true);
-      return;
-    }
-
     emit("update:data", formData.value);
 
     if (formData.value.businessInformation.clientType === "RSP") {
       validation.birthdate = false;
     }
+
+    const toggleErrorMessages = (
+      unsupportedLegalType: boolean | null = null,
+    ) => {
+      showUnsupportedLegalTypeError.value = unsupportedLegalType ?? false;
+
+      if (unsupportedLegalType) {
+        progressIndicatorBus.emit({ kind: "disabled", value: true });
+        exitBus.emit({
+          unsupportedLegalType
+        });
+      } else {
+        progressIndicatorBus.emit({ kind: "disabled", value: false });
+        exitBus.emit({
+          unsupportedLegalType: false
+        });
+      }
+    };
 
     //Also, we will load the backend data to fill all the other information as well
     const {
@@ -451,7 +446,7 @@ onMounted(() => {
       data-text="Client information"
       v-shadow="2"
       id="bcRegistrySearchNotification"
-      v-if="!formData.businessInformation.clientType && !showUnsupportedLegalTypeError"
+      v-if="!formData.businessInformation.clientType"
       low-contrast="true"
       open="true"
       kind="info"

--- a/legacy/src/test/java/ca/bc/gov/app/controller/ClientLocationControllerIntegrationTest.java
+++ b/legacy/src/test/java/ca/bc/gov/app/controller/ClientLocationControllerIntegrationTest.java
@@ -65,7 +65,7 @@ class ClientLocationControllerIntegrationTest extends
   }
 
   private static Stream<String> saveLocation() {
-    return Stream.of("00000001", "00000002", "00000008");
+    return Stream.of("00000001", "00000002", "00000005");
   }
 
   @ParameterizedTest

--- a/legacy/src/test/java/ca/bc/gov/app/controller/ClientLocationControllerIntegrationTest.java
+++ b/legacy/src/test/java/ca/bc/gov/app/controller/ClientLocationControllerIntegrationTest.java
@@ -65,7 +65,7 @@ class ClientLocationControllerIntegrationTest extends
   }
 
   private static Stream<String> saveLocation() {
-    return Stream.of("00000001", "00000002", "00000005");
+    return Stream.of("00000001", "00000002", "00000008");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Reverts bcgov/nr-forest-client#2364

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-forest-client-29-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-forest-client/actions/workflows/merge.yml)